### PR TITLE
github and customization mode

### DIFF
--- a/CustomizationSelect.sh
+++ b/CustomizationSelect.sh
@@ -605,14 +605,22 @@ function patch_command_line {
 
         for arg in "$@"
         do
+            found=false
             for i in "${!folder[@]}"
             do
                 if [[ "${folder[$i]}" == "$arg" ]]
                 then
                     apply_patch_command_line "$i"
+                    found=true
                     break
                 fi
             done
+
+            if ! $found
+            then
+                echo -e "${ERROR_FONT}  Unknown customization $arg${NC}"
+                exit 1
+            fi
         done
     else
         exit 1

--- a/CustomizationSelect.sh
+++ b/CustomizationSelect.sh
@@ -156,6 +156,12 @@ function exit_message() {
     section_divider
     exit 0
 }
+
+function erase_previous_line {
+    if [ -n "$TERM" ]; then
+        tput cuu1 && tput el 2>/dev/null || true
+    fi
+}
 # *** End of inlined file: inline_functions/common.sh ***
 
 
@@ -304,7 +310,7 @@ function debug_printout() {
 function cleanup {      
     echo "Deleting temp working directory $mytmpdir"
     rm -rf "$mytmpdir"
-    tput cuu1 && tput el
+    erase_previous_line
 
     if [ $param_zero_result -eq 1 ]; then
         exit_script
@@ -416,7 +422,7 @@ function download_patches {
         echo "Could not create temporary folder"
         exit 1
     fi
-    tput cuu1 && tput el
+    erase_previous_line
 
     # Register the cleanup function to be called on the EXIT signal
     trap cleanup EXIT
@@ -427,7 +433,7 @@ function download_patches {
         git clone --quiet --branch=$PATCH_BRANCH $PATCH_REPO
         clone_exit_status=$?
         if [ $clone_exit_status -eq 0 ]; then
-            tput cuu1 && tput el
+            erase_previous_line
             cd $workingdir
         else
             echo -e "❌ ${ERROR_FONT}An error occurred during download. Please investigate the issue.${NC}"

--- a/CustomizationSelect.sh
+++ b/CustomizationSelect.sh
@@ -180,7 +180,7 @@ one_time_flag=0
 
 # Determines if the $0 parameter should be used as a customization
 function param_zero_is_customization {
-    if [[ $0 == *CustomizationSelect.sh ]] || [[ $0 == "_" ]] || [[ -z $0 ]]; then
+    if [[ $0 == *CustomizationSelect.sh ]] || [[ $0 == "_" ]] || [[ $0 == "/bin/bash" ]] || [[ -z $0 ]]; then
         return 1  # This means false in bash
     else
         return 0  # This means true in bash

--- a/CustomizationSelect.sh
+++ b/CustomizationSelect.sh
@@ -599,6 +599,9 @@ function patch_command_line {
     # Verify current folder
     if [ $(basename $PWD) = "LoopWorkspace" ]; then
         download_patches
+        echo -e "${INFO_FONT}Directory where customizations will be applied:${NC}"
+        echo -e "${INFO_FONT}  ${workingdir/$HOME/~}${NC}"
+        echo
 
         for arg in "$@"
         do

--- a/CustomizationSelect.sh
+++ b/CustomizationSelect.sh
@@ -159,7 +159,7 @@ function exit_message() {
 
 function erase_previous_line {
     if [ -n "$TERM" ]; then
-        tput cuu1 && tput el 2>/dev/null || true
+        (tput cuu1 && tput el) 2>/dev/null || true
     fi
 }
 # *** End of inlined file: inline_functions/common.sh ***

--- a/inline_functions/common.sh
+++ b/inline_functions/common.sh
@@ -146,6 +146,6 @@ function exit_message() {
 
 function erase_previous_line {
     if [ -n "$TERM" ]; then
-        tput cuu1 && tput el 2>/dev/null || true
+        (tput cuu1 && tput el) 2>/dev/null || true
     fi
 }

--- a/inline_functions/common.sh
+++ b/inline_functions/common.sh
@@ -143,3 +143,9 @@ function exit_message() {
     section_divider
     exit 0
 }
+
+function erase_previous_line {
+    if [ -n "$TERM" ]; then
+        tput cuu1 && tput el 2>/dev/null || true
+    fi
+}

--- a/inline_functions/patch_functions.sh
+++ b/inline_functions/patch_functions.sh
@@ -21,7 +21,7 @@ one_time_flag=0
 
 # Determines if the $0 parameter should be used as a customization
 function param_zero_is_customization {
-    if [[ $0 == *CustomizationSelect.sh ]] || [[ $0 == "_" ]] || [[ -z $0 ]]; then
+    if [[ $0 == *CustomizationSelect.sh ]] || [[ $0 == "_" ]] || [[ $0 == "/bin/bash" ]] || [[ -z $0 ]]; then
         return 1  # This means false in bash
     else
         return 0  # This means true in bash

--- a/inline_functions/patch_functions.sh
+++ b/inline_functions/patch_functions.sh
@@ -145,7 +145,7 @@ function debug_printout() {
 function cleanup {      
     echo "Deleting temp working directory $mytmpdir"
     rm -rf "$mytmpdir"
-    tput cuu1 && tput el
+    erase_previous_line
 
     if [ $param_zero_result -eq 1 ]; then
         exit_script
@@ -257,7 +257,7 @@ function download_patches {
         echo "Could not create temporary folder"
         exit 1
     fi
-    tput cuu1 && tput el
+    erase_previous_line
 
     # Register the cleanup function to be called on the EXIT signal
     trap cleanup EXIT
@@ -268,7 +268,7 @@ function download_patches {
         git clone --quiet --branch=$PATCH_BRANCH $PATCH_REPO
         clone_exit_status=$?
         if [ $clone_exit_status -eq 0 ]; then
-            tput cuu1 && tput el
+            erase_previous_line
             cd $workingdir
         else
             echo -e "❌ ${ERROR_FONT}An error occurred during download. Please investigate the issue.${NC}"

--- a/inline_functions/patch_functions.sh
+++ b/inline_functions/patch_functions.sh
@@ -446,14 +446,22 @@ function patch_command_line {
 
         for arg in "$@"
         do
+            found=false
             for i in "${!folder[@]}"
             do
                 if [[ "${folder[$i]}" == "$arg" ]]
                 then
                     apply_patch_command_line "$i"
+                    found=true
                     break
                 fi
             done
+
+            if ! $found
+            then
+                echo -e "${ERROR_FONT}  Unknown customization $arg${NC}"
+                exit 1
+            fi
         done
     else
         exit 1

--- a/inline_functions/patch_functions.sh
+++ b/inline_functions/patch_functions.sh
@@ -440,6 +440,9 @@ function patch_command_line {
     # Verify current folder
     if [ $(basename $PWD) = "LoopWorkspace" ]; then
         download_patches
+        echo -e "${INFO_FONT}Directory where customizations will be applied:${NC}"
+        echo -e "${INFO_FONT}  ${workingdir/$HOME/~}${NC}"
+        echo
 
         for arg in "$@"
         do

--- a/inline_functions/patch_functions.sh
+++ b/inline_functions/patch_functions.sh
@@ -19,6 +19,15 @@ MAX_MENU_ITEM=$EXIT_OPEN_XCODE_MENU_ITEM
 
 one_time_flag=0
 
+# Determines if the $0 parameter should be used as a customization
+function param_zero_is_customization {
+    if [[ $0 == *CustomizationSelect.sh ]] || [[ $0 == "_" ]] || [[ -z $0 ]]; then
+        return 1  # This means false in bash
+    else
+        return 0  # This means true in bash
+    fi
+}
+
 function message_about_display() {
     echo -e "${INFO_FONT}You may need to scroll up to read everything${NC}"
     echo -e "${INFO_FONT} or drag corner to make terminal taller${NC}"
@@ -137,7 +146,10 @@ function cleanup {
     echo "Deleting temp working directory $mytmpdir"
     rm -rf "$mytmpdir"
     tput cuu1 && tput el
-    exit_script
+
+    if [ $param_zero_result -eq 1 ]; then
+        exit_script
+    fi    
 }
 
 function display_applied_patches() {
@@ -198,6 +210,24 @@ function apply_patch {
     refresh_status
 }
 
+function apply_patch_command_line {
+    local index=$1
+    local patch_file="${patch[$index]}"
+    local customization_name="${customization[$index]}"
+    if [ -f "$patch_file" ]; then
+        if git apply --whitespace=nowarn "$patch_file"; then
+            echo -e "${SUCCESS_FONT}  Customization $customization_name applied successfully${NC}"
+        else
+            echo -e "${ERROR_FONT}  Failed to apply customization $customization_name${NC}"
+            exit 1
+        fi
+    else
+        echo -e "${ERROR_FONT}  Patch file for customization $customization_name not available${NC}"
+        exit 1
+    fi
+    refresh_status
+}
+
 function revert_patch {
     local index=$1
     local patch_file="${patch[$index]}"
@@ -215,6 +245,41 @@ function revert_patch {
         return_when_return
     fi
     refresh_status
+}
+
+function download_patches {
+    echo "Creating temporary folder"
+    workingdir=$PWD
+    mytmpdir=$(mktemp -d)
+
+    # Check if tmp dir was created
+    if [[ ! "$mytmpdir" || ! -d "$mytmpdir" ]]; then
+        echo "Could not create temporary folder"
+        exit 1
+    fi
+    tput cuu1 && tput el
+
+    # Register the cleanup function to be called on the EXIT signal
+    trap cleanup EXIT
+
+    if [ -z "$LOCAL_PATCH_FOLDER" ]; then
+        echo -e "${INFO_FONT}Downloading customizations, please wait  ...  patiently  ...${NC}"
+        cd $mytmpdir
+        git clone --quiet --branch=$PATCH_BRANCH $PATCH_REPO
+        clone_exit_status=$?
+        if [ $clone_exit_status -eq 0 ]; then
+            tput cuu1 && tput el
+            cd $workingdir
+        else
+            echo -e "❌ ${ERROR_FONT}An error occurred during download. Please investigate the issue.${NC}"
+            exit 1
+        fi
+    fi
+
+    refresh_status
+    if [ $DEBUG_FLAG -eq 1 ]; then
+        debug_printout
+    fi
 }
 
 function patch_menu {
@@ -235,39 +300,7 @@ function patch_menu {
 
     # Verify current folder
     if [ $(basename $PWD) = "LoopWorkspace" ]; then
-        echo "Creating temporary folder"
-        workingdir=$PWD
-        mytmpdir=$(mktemp -d)
-
-        # Check if tmp dir was created
-        if [[ ! "$mytmpdir" || ! -d "$mytmpdir" ]]; then
-            echo "Could not create temporary folder"
-            exit 1
-        fi
-        tput cuu1 && tput el
-
-        # Register the cleanup function to be called on the EXIT signal
-        trap cleanup EXIT
-
-        if [ -z "$LOCAL_PATCH_FOLDER" ]; then
-            echo -e "${INFO_FONT}Downloading customizations, please wait  ...  patiently  ...${NC}"
-            cd $mytmpdir
-            git clone --quiet --branch=$PATCH_BRANCH $PATCH_REPO
-            clone_exit_status=$?
-            if [ $clone_exit_status -eq 0 ]; then
-                tput cuu1 && tput el
-                cd $workingdir
-            else
-                echo -e "❌ ${ERROR_FONT}An error occurred during download. Please investigate the issue.${NC}"
-                exit 1
-            fi
-        fi
-
-        refresh_status
-        if [ $DEBUG_FLAG -eq 1 ]; then
-            debug_printout
-        fi
-
+        download_patches
         echo
 
         ### repeating menu start here:
@@ -381,6 +414,43 @@ function patch_menu {
                 return_when_ready
             fi            
             section_separator
+        done
+    else
+        exit 1
+    fi
+}
+
+function patch_command_line {
+    section_separator
+    echo -e "${INFO_FONT}Loop Customization Select Script${NC}"
+
+    cd "$STARTING_DIR"
+
+    if [ "$(basename "$PWD")" != "LoopWorkspace" ]; then
+        target_dir=$(find ${BUILD_DIR/#\~/$HOME} -maxdepth 1 -type d -name "Loop*" -exec [ -d "{}"/LoopWorkspace ] \; -print 2>/dev/null | xargs -I {} stat -f "%m %N" {} | sort -rn | head -n 1 | awk '{print $2"/LoopWorkspace"}')
+        if [ -z "$target_dir" ]; then
+            echo -e "${ERROR_FONT}Error: No folder containing LoopWorkspace found in${NC}"
+            echo "    $BUILD_DIR"
+            exit 1
+        else
+            cd "$target_dir"
+        fi
+    fi
+
+    # Verify current folder
+    if [ $(basename $PWD) = "LoopWorkspace" ]; then
+        download_patches
+
+        for arg in "$@"
+        do
+            for i in "${!folder[@]}"
+            do
+                if [[ "${folder[$i]}" == "$arg" ]]
+                then
+                    apply_patch_command_line "$i"
+                    break
+                fi
+            done
         done
     else
         exit 1

--- a/src/CustomizationSelect.sh
+++ b/src/CustomizationSelect.sh
@@ -77,5 +77,13 @@ add_customization "Profile Save & Load" "2002" "message_for_pr2002"
 add_customization "Glucose Based Application Factor" "1988" "message_for_pr1988"
 add_customization "Integral Retrospective Correction" "2008" "message_for_pr2008"
 
+param_zero_is_customization
+param_zero_result=$?
 
-patch_menu
+if [ $param_zero_result -eq 0 ]; then
+    patch_command_line $0 "$@"
+elif [ $# -gt 0 ]; then
+    patch_command_line "$@"
+else
+    patch_menu
+fi


### PR DESCRIPTION
Improved customization select script intended for github use. But can also be used for frequent xcode builders always wanting the same set of patches, instead of typing those menu numbers.

/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/loopandlearn/lnl-scripts/github-patch/CustomizationSelect.sh)" 1988 2002 lnl_icon