### PR TITLE
Fix for empty line

### DIFF
--- a/CustomizationSelect.sh
+++ b/CustomizationSelect.sh
@@ -716,7 +716,12 @@ if [ $param_zero_result -eq 0 ]; then
 elif [ $# -gt 0 ] && [ -n "$1" ]; then
     patch_command_line "$@"
 else
-    patch_menu
+    if [ "$GITHUB_ACTIONS" != "true" ]; then
+        patch_menu
+    else
+        echo -e "${ERROR_FONT}  Customization in Browser Build executed without parameters, check that there is no empty line after CustomizationSelect.sh.{NC}"
+        exit 1
+    fi
 fi
 # *** End of inlined file: src/CustomizationSelect.sh ***
 

--- a/src/CustomizationSelect.sh
+++ b/src/CustomizationSelect.sh
@@ -83,5 +83,10 @@ if [ $param_zero_result -eq 0 ]; then
 elif [ $# -gt 0 ] && [ -n "$1" ]; then
     patch_command_line "$@"
 else
-    patch_menu
+    if [ "$GITHUB_ACTIONS" != "true" ]; then
+        patch_menu
+    else
+        echo -e "${ERROR_FONT}  Customization in Browser Build executed without parameters, check that there is no empty line after CustomizationSelect.sh.{NC}"
+        exit 1
+    fi
 fi


### PR DESCRIPTION
Gives an error message if there is an empty line before the customizations are listed.

<img width="991" alt="CleanShot 2023-07-02 at 14 34 32@2x" src="https://github.com/loopandlearn/lnl-scripts/assets/12718238/2208137c-168d-4edc-8829-eab247abdf47">

https://github.com/bjorkert/LoopWorkspace/actions/runs/5436534493/jobs/9886472848