### PR TITLE
Bring 'lightly tested' to a commit with IOS17 compatible widget

### DIFF
--- a/BuildLoopDev.sh
+++ b/BuildLoopDev.sh
@@ -760,8 +760,8 @@ open_source_warning
 ############################################################
 
 # Stable Dev SHA
-FIXED_SHA="510ef81"
-FIXED_COMMIT_DATE="2023-Jul-27"
+FIXED_SHA="ca36d07"
+FIXED_COMMIT_DATE="2023-Aug-16"
 FLAG_USE_SHA=0
 
 URL_THIS_SCRIPT="https://github.com/LoopKit/LoopWorkspace.git"


### PR DESCRIPTION
This PR brings the lightly tested dev commit forwards a few weeks to LoopKit/LoopWorkspace@ca36d07 which has an ios17 compatible widget.

c.f.
https://loop.zulipchat.com/#narrow/stream/148543-Loop/topic/Loop.20Status.20Widgets.20Issue/near/383988989