### PR TITLE
update lightly tested SHA for BuildLoopDev

### DIFF
--- a/BuildLoopDev.sh
+++ b/BuildLoopDev.sh
@@ -760,8 +760,8 @@ open_source_warning
 ############################################################
 
 # Stable Dev SHA
-FIXED_SHA="510ef81"
-FIXED_COMMIT_DATE="2023-Jul-27"
+FIXED_SHA="a9e4404"
+FIXED_COMMIT_DATE="2023-Sep-11"
 FLAG_USE_SHA=0
 
 URL_THIS_SCRIPT="https://github.com/LoopKit/LoopWorkspace.git"

--- a/src/BuildLoopDev.sh
+++ b/src/BuildLoopDev.sh
@@ -24,8 +24,8 @@ open_source_warning
 ############################################################
 
 # Stable Dev SHA
-FIXED_SHA="510ef81"
-FIXED_COMMIT_DATE="2023-Jul-27"
+FIXED_SHA="a9e4404"
+FIXED_COMMIT_DATE="2023-Sep-11"
 FLAG_USE_SHA=0
 
 URL_THIS_SCRIPT="https://github.com/LoopKit/LoopWorkspace.git"


### PR DESCRIPTION
Bring SHA up to latest version of Loop dev branch from Sep 11 on Sep 20.