### PR TITLE
Add support for specific SHA checkout in Build_iAPS script

### DIFF
--- a/Build_iAPS.sh
+++ b/Build_iAPS.sh
@@ -911,7 +911,6 @@ section_divider
 before_final_return_message
 echo -e ""
 return_when_ready
-cd $REPO_NAME
 xed . 
 after_final_return_message
 exit_script

--- a/Build_iAPS.sh
+++ b/Build_iAPS.sh
@@ -19,6 +19,9 @@ DEV_TEAM_SETTING_NAME="DEVELOPER_TEAM"
 # sub modules are not required
 CLONE_SUB_MODULES="0"
 
+FLAG_USE_SHA=0  # Initialize FLAG_USE_SHA to 0
+FIXED_SHA=""    # Initialize FIXED_SHA with an empty string
+
 
 # *** Start of inlined file: inline_functions/build_functions.sh ***
 
@@ -830,13 +833,11 @@ run_script() {
 
 open_source_warning
 
-
 ############################################################
 # Welcome & Branch Selection
 ############################################################
 
 URL_THIS_SCRIPT="https://github.com/Artificial-Pancreas/iAPS.git"
-
 
 function select_iaps_main() {
     branch_select ${URL_THIS_SCRIPT} main
@@ -844,6 +845,12 @@ function select_iaps_main() {
 
 function select_iaps_dev() {
     branch_select ${URL_THIS_SCRIPT} dev
+}
+
+function select_iaps_tested_main() {
+    FLAG_USE_SHA=1
+    FIXED_SHA="f404fc4"
+    branch_select ${URL_THIS_SCRIPT} dev iAPS_main_${FIXED_SHA}
 }
 
 if [ -z "$CUSTOM_BRANCH" ]; then
@@ -863,8 +870,8 @@ if [ -z "$CUSTOM_BRANCH" ]; then
         echo -e "  https://www.loopandlearn.org/build-select/#utilities-disk"
         echo -e ""
 
-        options=("iAPS main" "iAPS dev" "Run Maintenance Utilities" "$(exit_or_return_menu)")
-        actions=("select_iaps_main" "select_iaps_dev" "utility_scripts" "exit_script")
+        options=("iAPS 2.3.3 tested main" "iAPS main" "iAPS dev" "Run Maintenance Utilities" "$(exit_or_return_menu)")
+        actions=("select_iaps_tested_main" "select_iaps_main" "select_iaps_dev" "utility_scripts" "exit_script")
         menu_select "${options[@]}" "${actions[@]}"
     done
 else
@@ -875,8 +882,26 @@ fi
 # Standard Build train
 ############################################################
 
-standard_build_train
+verify_xcode_path
+clone_repo
+automated_clone_download_error_check
 
+# special build train for lightly tested commit
+cd $REPO_NAME
+
+this_dir="$(pwd)"
+echo -e "In ${this_dir}"
+if [ ${FLAG_USE_SHA} == 1 ]; then
+    echo -e "  Checking out commit ${FIXED_SHA}\n"
+    git checkout ${FIXED_SHA} --recurse-submodules --quiet
+    git describe --tags --exact-match
+    git rev-parse HEAD
+    echo -e "Continue if no errors reported"
+    return_when_ready
+fi
+
+check_config_override_existence_offer_to_configure
+ensure_a_year
 
 ############################################################
 # Open Xcode

--- a/DeleteOldDownloads.sh
+++ b/DeleteOldDownloads.sh
@@ -311,7 +311,8 @@ function delete_old_downloads() {
         "BuildLoopFollow/LoopFollow_dev*"
         "BuildxDrip4iOS/xDrip4iOS*"
         "BuildGlucoseDirect/GlucoseDirect*"
-        "Build_iAPS/iAPS_main*"
+        "Build_iAPS/iAPS_main_*"
+        "Build_iAPS/iAPS_main-*"
         "Build_iAPS/iAPS_dev*"
     )
 

--- a/inline_functions/delete_old_downloads.sh
+++ b/inline_functions/delete_old_downloads.sh
@@ -144,7 +144,8 @@ function delete_old_downloads() {
         "BuildLoopFollow/LoopFollow_dev*"
         "BuildxDrip4iOS/xDrip4iOS*"
         "BuildGlucoseDirect/GlucoseDirect*"
-        "Build_iAPS/iAPS_main*"
+        "Build_iAPS/iAPS_main_*"
+        "Build_iAPS/iAPS_main-*"
         "Build_iAPS/iAPS_dev*"
     )
 

--- a/src/Build_iAPS.sh
+++ b/src/Build_iAPS.sh
@@ -14,6 +14,9 @@ DEV_TEAM_SETTING_NAME="DEVELOPER_TEAM"
 # sub modules are not required
 CLONE_SUB_MODULES="0"
 
+FLAG_USE_SHA=0  # Initialize FLAG_USE_SHA to 0
+FIXED_SHA=""    # Initialize FIXED_SHA with an empty string
+
 #!inline build_functions.sh
 #!inline utility_scripts.sh
 #!inline run_script.sh
@@ -27,13 +30,11 @@ CLONE_SUB_MODULES="0"
 
 open_source_warning
 
-
 ############################################################
 # Welcome & Branch Selection
 ############################################################
 
 URL_THIS_SCRIPT="https://github.com/Artificial-Pancreas/iAPS.git"
-
 
 function select_iaps_main() {
     branch_select ${URL_THIS_SCRIPT} main
@@ -41,6 +42,12 @@ function select_iaps_main() {
 
 function select_iaps_dev() {
     branch_select ${URL_THIS_SCRIPT} dev
+}
+
+function select_iaps_tested_main() {
+    FLAG_USE_SHA=1
+    FIXED_SHA="f404fc4"
+    branch_select ${URL_THIS_SCRIPT} dev iAPS_main_${FIXED_SHA}
 }
 
 if [ -z "$CUSTOM_BRANCH" ]; then
@@ -60,8 +67,8 @@ if [ -z "$CUSTOM_BRANCH" ]; then
         echo -e "  https://www.loopandlearn.org/build-select/#utilities-disk"
         echo -e ""
 
-        options=("iAPS main" "iAPS dev" "Run Maintenance Utilities" "$(exit_or_return_menu)")
-        actions=("select_iaps_main" "select_iaps_dev" "utility_scripts" "exit_script")
+        options=("iAPS 2.3.3 tested main" "iAPS main" "iAPS dev" "Run Maintenance Utilities" "$(exit_or_return_menu)")
+        actions=("select_iaps_tested_main" "select_iaps_main" "select_iaps_dev" "utility_scripts" "exit_script")
         menu_select "${options[@]}" "${actions[@]}"
     done
 else
@@ -72,8 +79,26 @@ fi
 # Standard Build train
 ############################################################
 
-standard_build_train
+verify_xcode_path
+clone_repo
+automated_clone_download_error_check
 
+# special build train for lightly tested commit
+cd $REPO_NAME
+
+this_dir="$(pwd)"
+echo -e "In ${this_dir}"
+if [ ${FLAG_USE_SHA} == 1 ]; then
+    echo -e "  Checking out commit ${FIXED_SHA}\n"
+    git checkout ${FIXED_SHA} --recurse-submodules --quiet
+    git describe --tags --exact-match
+    git rev-parse HEAD
+    echo -e "Continue if no errors reported"
+    return_when_ready
+fi
+
+check_config_override_existence_offer_to_configure
+ensure_a_year
 
 ############################################################
 # Open Xcode

--- a/src/Build_iAPS.sh
+++ b/src/Build_iAPS.sh
@@ -108,7 +108,6 @@ section_divider
 before_final_return_message
 echo -e ""
 return_when_ready
-cd $REPO_NAME
 xed . 
 after_final_return_message
 exit_script


### PR DESCRIPTION
### Changes:
- Initialized `FLAG_USE_SHA` and `FIXED_SHA` variables to enable checkout of a specific SHA.
- Added `select_iaps_tested_main` function to allow users to select the iAPS 2.3.3 tested main branch with SHA `f404fc4`.
- Modified the build train to include a conditional checkout based on `FLAG_USE_SHA`, allowing the script to checkout the specified SHA post-repository cloning.

### Purpose:
The updates to the `Build_iAPS.sh` script are intended to enhance its flexibility and usability. By allowing users to select a specific, tested state of the iAPS main branch (2.3.3 with SHA `f404fc4`), we aim to provide a more stable option for those who prefer to build from a known good state. This change is particularly useful for environments where stability is paramount, and it complements the existing options to build from the latest commits on the main and dev branches.

### Testing:
- Tested the new option to ensure the correct SHA is checked out and that the script behaves as expected in scenarios where `FLAG_USE_SHA` is set to `1`.
- Verified that existing functionality to build from the latest main and dev branches remains unaffected.

Command to test this version:
`export SCRIPT_BRANCH=iaps-versions&&/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/loopandlearn/lnl-scripts/iaps-versions/Build_iAPS.sh)"`