### PR TITLE
Update iOS, Xcode, and macOS version requirements

### DIFF
--- a/BuildFreeAPS.sh
+++ b/BuildFreeAPS.sh
@@ -334,14 +334,14 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
 #This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.2.1"
+LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.0"
+LOWEST_XCODE_VER="15.2"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.2"
+LATEST_XCODE_VER="15.3"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
 LOWEST_MACOS_VER="13.5"

--- a/BuildFreeAPS.sh
+++ b/BuildFreeAPS.sh
@@ -337,7 +337,7 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.2"
+LOWEST_XCODE_VER="15.1"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these

--- a/BuildGlucoseDirect.sh
+++ b/BuildGlucoseDirect.sh
@@ -343,7 +343,7 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.2"
+LOWEST_XCODE_VER="15.1"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these

--- a/BuildGlucoseDirect.sh
+++ b/BuildGlucoseDirect.sh
@@ -340,14 +340,14 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
 #This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.2.1"
+LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.0"
+LOWEST_XCODE_VER="15.2"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.2"
+LATEST_XCODE_VER="15.3"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
 LOWEST_MACOS_VER="13.5"

--- a/BuildLoopCaregiver.sh
+++ b/BuildLoopCaregiver.sh
@@ -334,14 +334,14 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
 #This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.2.1"
+LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.0"
+LOWEST_XCODE_VER="15.2"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.2"
+LATEST_XCODE_VER="15.3"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
 LOWEST_MACOS_VER="13.5"

--- a/BuildLoopCaregiver.sh
+++ b/BuildLoopCaregiver.sh
@@ -337,7 +337,7 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.2"
+LOWEST_XCODE_VER="15.1"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these

--- a/BuildLoopDev.sh
+++ b/BuildLoopDev.sh
@@ -334,14 +334,14 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
 #This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.2.1"
+LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.0"
+LOWEST_XCODE_VER="15.2"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.2"
+LATEST_XCODE_VER="15.3"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
 LOWEST_MACOS_VER="13.5"

--- a/BuildLoopDev.sh
+++ b/BuildLoopDev.sh
@@ -337,7 +337,7 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.2"
+LOWEST_XCODE_VER="15.1"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these

--- a/BuildLoopFollow.sh
+++ b/BuildLoopFollow.sh
@@ -335,14 +335,14 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
 #This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.2.1"
+LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.0"
+LOWEST_XCODE_VER="15.2"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.2"
+LATEST_XCODE_VER="15.3"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
 LOWEST_MACOS_VER="13.5"

--- a/BuildLoopFollow.sh
+++ b/BuildLoopFollow.sh
@@ -338,7 +338,7 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.2"
+LOWEST_XCODE_VER="15.1"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these

--- a/BuildLoopReleased.sh
+++ b/BuildLoopReleased.sh
@@ -334,14 +334,14 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
 #This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.2.1"
+LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.0"
+LOWEST_XCODE_VER="15.2"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.2"
+LATEST_XCODE_VER="15.3"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
 LOWEST_MACOS_VER="13.5"

--- a/BuildLoopReleased.sh
+++ b/BuildLoopReleased.sh
@@ -337,7 +337,7 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.2"
+LOWEST_XCODE_VER="15.1"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these

--- a/Build_iAPS.sh
+++ b/Build_iAPS.sh
@@ -345,7 +345,7 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.2"
+LOWEST_XCODE_VER="15.1"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these

--- a/Build_iAPS.sh
+++ b/Build_iAPS.sh
@@ -342,14 +342,14 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
 #This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.2.1"
+LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.0"
+LOWEST_XCODE_VER="15.2"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.2"
+LATEST_XCODE_VER="15.3"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
 LOWEST_MACOS_VER="13.5"

--- a/BuildxDrip4iOS.sh
+++ b/BuildxDrip4iOS.sh
@@ -345,7 +345,7 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.2"
+LOWEST_XCODE_VER="15.1"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these

--- a/BuildxDrip4iOS.sh
+++ b/BuildxDrip4iOS.sh
@@ -342,14 +342,14 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
 #This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.2.1"
+LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.0"
+LOWEST_XCODE_VER="15.2"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.2"
+LATEST_XCODE_VER="15.3"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
 LOWEST_MACOS_VER="13.5"

--- a/inline_functions/building_verify_version.sh
+++ b/inline_functions/building_verify_version.sh
@@ -1,13 +1,13 @@
 #This should be the latest iOS version
 #This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.2.1"
+LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.0"
+LOWEST_XCODE_VER="15.2"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.2"
+LATEST_XCODE_VER="15.3"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
 LOWEST_MACOS_VER="13.5"

--- a/inline_functions/building_verify_version.sh
+++ b/inline_functions/building_verify_version.sh
@@ -3,7 +3,7 @@
 LATEST_IOS_VER="17.4"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.2"
+LOWEST_XCODE_VER="15.1"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these


### PR DESCRIPTION
This pull request updates the iOS, Xcode, and macOS version requirements across multiple build scripts to ensure compatibility with the latest versions. The changes include an update from iOS 17.2.1 to 17.4, Xcode from 15.0/15.2 to 15.1/15.3, and retain the minimum macOS version at 13.5.

Note - official Apple site claims 15.2 is required, but in practice, 15.1 was sufficient for our DIY apps.