### PR TITLE
Added check_versions call in BuildLoopDev.sh and Build_iAPS.sh scripts

### DIFF
--- a/BuildLoopDev.sh
+++ b/BuildLoopDev.sh
@@ -798,6 +798,7 @@ fi
 ############################################################
 
 verify_xcode_path
+check_versions
 clone_repo
 automated_clone_download_error_check
 

--- a/Build_iAPS.sh
+++ b/Build_iAPS.sh
@@ -883,6 +883,7 @@ fi
 ############################################################
 
 verify_xcode_path
+check_versions
 clone_repo
 automated_clone_download_error_check
 

--- a/src/BuildLoopDev.sh
+++ b/src/BuildLoopDev.sh
@@ -65,6 +65,7 @@ fi
 ############################################################
 
 verify_xcode_path
+check_versions
 clone_repo
 automated_clone_download_error_check
 

--- a/src/Build_iAPS.sh
+++ b/src/Build_iAPS.sh
@@ -80,6 +80,7 @@ fi
 ############################################################
 
 verify_xcode_path
+check_versions
 clone_repo
 automated_clone_download_error_check
 


### PR DESCRIPTION
Added check_versions call in BuildLoopDev.sh and Build_iAPS.sh scripts, ensuring version validation occurs immediately after verifying the Xcode path and before cloning the repository.