### PR TITLE
update lightly tested SHA for loop-dev

### DIFF
--- a/BuildLoopDev.sh
+++ b/BuildLoopDev.sh
@@ -757,8 +757,8 @@ open_source_warning
 ############################################################
 
 # Stable Dev SHA
-FIXED_SHA="c4b4588"
-FIXED_COMMIT_DATE="2024-May-19"
+FIXED_SHA="3542408"
+FIXED_COMMIT_DATE="2024-Jul-06"
 FLAG_USE_SHA=0
 
 URL_THIS_SCRIPT="https://github.com/LoopKit/LoopWorkspace.git"

--- a/src/BuildLoopDev.sh
+++ b/src/BuildLoopDev.sh
@@ -24,8 +24,8 @@ open_source_warning
 ############################################################
 
 # Stable Dev SHA
-FIXED_SHA="c4b4588"
-FIXED_COMMIT_DATE="2024-May-19"
+FIXED_SHA="3542408"
+FIXED_COMMIT_DATE="2024-Jul-06"
 FLAG_USE_SHA=0
 
 URL_THIS_SCRIPT="https://github.com/LoopKit/LoopWorkspace.git"


### PR DESCRIPTION
Update to the latest dev version. This has been out for a week and is the likely candidate for Loop release 3.4