### PR TITLE
Modifications to support release of 3.4

### DIFF
--- a/BuildSelectScript.sh
+++ b/BuildSelectScript.sh
@@ -350,32 +350,7 @@ while true; do
         # Issue Warning if not done previously
         open_source_warning
 
-        section_separator
-        echo -e "${INFO_FONT}Until the current dev branch is released as 3.4, this script"
-        echo -e "  has options for released (3.2.3) or dev (3.3.0) version${NC}"
-        echo -e
-        echo -e "  Each option has additional information once you make your choice"
-        echo -e
-        echo -e "If choosing dev, please select the ${INFO_FONT}lightly tested${NC} option"
-        echo -e
-
-        return_when_ready
-
-        options=(\
-            "Build Loop main (3.2.3)" \
-            "Build Loop dev  (3.3.0)" \
-            "Return to Menu")
-        actions=(\
-            "WHICH=LoopReleased" \
-            "WHICH=LoopDev" \
-            return)
-        menu_select "${options[@]}" "${actions[@]}"
-
-        if [ "$WHICH" = "LoopReleased" ]; then
-            run_script "BuildLoopReleased.sh" $CUSTOM_BRANCH
-        elif  [ "$WHICH" = "LoopDev" ]; then
-            run_script "BuildLoopDev.sh" $CUSTOM_BRANCH
-        fi
+        run_script "BuildLoopReleased.sh" $CUSTOM_BRANCH
 
 
     elif [ "$WHICH" = "OtherApps" ]; then

--- a/src/BuildSelectScript.sh
+++ b/src/BuildSelectScript.sh
@@ -65,32 +65,7 @@ while true; do
         # Issue Warning if not done previously
         open_source_warning
 
-        section_separator
-        echo -e "${INFO_FONT}Until the current dev branch is released as 3.4, this script"
-        echo -e "  has options for released (3.2.3) or dev (3.3.0) version${NC}"
-        echo -e
-        echo -e "  Each option has additional information once you make your choice"
-        echo -e
-        echo -e "If choosing dev, please select the ${INFO_FONT}lightly tested${NC} option"
-        echo -e
-
-        return_when_ready
-
-        options=(\
-            "Build Loop main (3.2.3)" \
-            "Build Loop dev  (3.3.0)" \
-            "Return to Menu")
-        actions=(\
-            "WHICH=LoopReleased" \
-            "WHICH=LoopDev" \
-            return)
-        menu_select "${options[@]}" "${actions[@]}"
-
-        if [ "$WHICH" = "LoopReleased" ]; then
-            run_script "BuildLoopReleased.sh" $CUSTOM_BRANCH
-        elif  [ "$WHICH" = "LoopDev" ]; then
-            run_script "BuildLoopDev.sh" $CUSTOM_BRANCH
-        fi
+        run_script "BuildLoopReleased.sh" $CUSTOM_BRANCH
 
 
     elif [ "$WHICH" = "OtherApps" ]; then


### PR DESCRIPTION
* Remove access to BuildLoopDev inside BuildSelectScript with 3.4 release
* Remove comments about while waiting for release 3.4 and label of 3.2.3 for main
* Undo the changes to BuildSelectScript.sh from PR #54 