### PR TITLE
Updates for Xcode 16, iOS 18

### DIFF
--- a/BuildGlucoseDirect.sh
+++ b/BuildGlucoseDirect.sh
@@ -598,9 +598,7 @@ function ensure_a_year() {
     do
         case $opt in
             "Ensure a Year")
-                rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-                echo -e "✅ ${SUCCESS_FONT}Profiles were cleaned${NC}"
-                echo -e "   Next app you build with Xcode will last a year"
+                clean_profiles
                 break
                 ;;
             "Skip")

--- a/BuildGlucoseDirect.sh
+++ b/BuildGlucoseDirect.sh
@@ -301,13 +301,20 @@ function after_final_return_message() {
 # clean provisioning profiles saved on disk
 
 # *** Start of inlined file: inline_functions/clean_profiles.sh ***
+############################################################
+# clean_profiles function
+#   Action: deletes saved mobileprovisions from Mac
+#   Information:
+#     If Xcode is open, *.mobileprovisions are deleted and new ones generated
+#     The path changed between Xcode 15 and Xcode 16, delete both folders
+############################################################
+
 clean_profiles() {
-    echo -e "\n✅ Cleaning Profiles"
-    echo -e "     This ensures the next app you build with Xcode will last a year."
-    # The path changed between Xcode 15 and Xcode 16, delete both locations
     xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
     xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
 
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
     if [[ -d "$xcode15_path" ]]; then
         rm -rf "$xcode15_path"
     fi

--- a/BuildGlucoseDirect.sh
+++ b/BuildGlucoseDirect.sh
@@ -298,6 +298,27 @@ function after_final_return_message() {
 # *** End of inlined file: inline_functions/before_final_return_message.sh ***
 
 
+# clean provisioning profiles saved on disk
+
+# *** Start of inlined file: inline_functions/clean_profiles.sh ***
+clean_profiles() {
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
+    # The path changed between Xcode 15 and Xcode 16, delete both locations
+    xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
+    xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+
+    if [[ -d "$xcode15_path" ]]; then
+        rm -rf "$xcode15_path"
+    fi
+    if [[ -d "$xcode16_path" ]]; then
+        rm -rf "$xcode16_path"
+    fi
+    echo -e "✅ Profiles are cleaned."
+}
+# *** End of inlined file: inline_functions/clean_profiles.sh ***
+
+
 ############################################################
 # Common functions used by multiple build scripts
 #    - Start of build_functions.sh common code

--- a/BuildGlucoseDirect.sh
+++ b/BuildGlucoseDirect.sh
@@ -370,7 +370,7 @@ LOWEST_XCODE_VER="15.4"
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
 LATEST_XCODE_VER="16.0"
 
-#This is the lowest version of macOS required to run LATEST_XCODE_VER
+#This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
@@ -388,7 +388,7 @@ function check_versions() {
     echo "Verifying Xcode and macOS versions..."
 
     if ! command -v xcodebuild >/dev/null; then
-        echo "Xcode not found. Please install Xcode and try again."
+        echo "  Xcode not found. Please install Xcode and try again."
         exit_or_return_menu
     fi
 
@@ -404,12 +404,15 @@ function check_versions() {
         MACOS_VER=$(sw_vers -productVersion)
     fi
 
-    echo "Xcode found: Version $XCODE_VER"
+    echo "  Xcode found: Version $XCODE_VER"
 
     # Check if Xcode version is greater than the latest known version
     if [ "$(compare_versions "$XCODE_VER" "$LATEST_XCODE_VER")" = "$LATEST_XCODE_VER" ] && [ "$XCODE_VER" != "$LATEST_XCODE_VER" ]; then
-        echo "You have a newer Xcode version ($XCODE_VER) than the latest known by this script ($LATEST_XCODE_VER)."
-        echo "Please verify your versions using https://www.loopandlearn.org/version-updates/ and https://developer.apple.com/support/xcode/"
+        echo ""
+        echo "You have a newer Xcode version ($XCODE_VER) than"
+        echo "  the latest released version known by this script ($LATEST_XCODE_VER)."
+        echo "You can probably continue; but if you have problems, refer to"
+        echo "    https://developer.apple.com/support/xcode/"
 
         options=("Continue" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
@@ -417,17 +420,25 @@ function check_versions() {
     # Check if Xcode version is less than the lowest required version
     elif [ "$(compare_versions "$XCODE_VER" "$LOWEST_XCODE_VER")" = "$XCODE_VER" ] && [ "$XCODE_VER" != "$LOWEST_XCODE_VER" ]; then
         if [ "$(compare_versions "$MACOS_VER" "$LOWEST_MACOS_VER")" != "$LOWEST_MACOS_VER" ]; then
-            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER. Please update macOS to version $LOWEST_MACOS_VER or later."
-            echo "If you can't update, follow the GitHub build option here: https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
+            echo ""
+            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER"
+            echo "  required to build for iOS $LATEST_IOS_VER."
+            echo "Please update macOS to version $LOWEST_MACOS_VER or later."
+            echo ""
+            echo "If you can't update, follow the GitHub build option here:"
+            echo "  https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
         fi
 
+        echo ""
         echo "You need to upgrade Xcode to version $LOWEST_XCODE_VER or later to build for iOS $LATEST_IOS_VER."
+        echo "If your iOS is at a lower version, refer to the compatibility table in LoopDocs"
+        echo "  https://loopkit.github.io/loopdocs/build/xcode-version/#compatible-versions"
 
         options=("Continue with lower iOS version" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
         menu_select "${options[@]}" "${actions[@]}"
     else 
-        echo "You have a Xcode version ($XCODE_VER) which can build for iOS $LATEST_IOS_VER."
+        echo "Your Xcode version can build up to iOS $LATEST_IOS_VER."
     fi
 }
 # *** End of inlined file: inline_functions/building_verify_version.sh ***

--- a/BuildGlucoseDirect.sh
+++ b/BuildGlucoseDirect.sh
@@ -360,18 +360,18 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
-#This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.5"
+#This is the highest version we expect users to have on their iPhones
+LATEST_IOS_VER="18.0"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.3"
+LOWEST_XCODE_VER="15.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.4"
+LATEST_XCODE_VER="16.0"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
-LOWEST_MACOS_VER="14"
+LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
 # sorts them in ascending order using the sort command with the -V flag (version sorting),

--- a/BuildLoopCaregiver.sh
+++ b/BuildLoopCaregiver.sh
@@ -295,13 +295,20 @@ function after_final_return_message() {
 # clean provisioning profiles saved on disk
 
 # *** Start of inlined file: inline_functions/clean_profiles.sh ***
+############################################################
+# clean_profiles function
+#   Action: deletes saved mobileprovisions from Mac
+#   Information:
+#     If Xcode is open, *.mobileprovisions are deleted and new ones generated
+#     The path changed between Xcode 15 and Xcode 16, delete both folders
+############################################################
+
 clean_profiles() {
-    echo -e "\n✅ Cleaning Profiles"
-    echo -e "     This ensures the next app you build with Xcode will last a year."
-    # The path changed between Xcode 15 and Xcode 16, delete both locations
     xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
     xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
 
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
     if [[ -d "$xcode15_path" ]]; then
         rm -rf "$xcode15_path"
     fi

--- a/BuildLoopCaregiver.sh
+++ b/BuildLoopCaregiver.sh
@@ -354,18 +354,18 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
-#This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.5"
+#This is the highest version we expect users to have on their iPhones
+LATEST_IOS_VER="18.0"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.3"
+LOWEST_XCODE_VER="15.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.4"
+LATEST_XCODE_VER="16.0"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
-LOWEST_MACOS_VER="14"
+LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
 # sorts them in ascending order using the sort command with the -V flag (version sorting),

--- a/BuildLoopCaregiver.sh
+++ b/BuildLoopCaregiver.sh
@@ -592,9 +592,7 @@ function ensure_a_year() {
     do
         case $opt in
             "Ensure a Year")
-                rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-                echo -e "✅ ${SUCCESS_FONT}Profiles were cleaned${NC}"
-                echo -e "   Next app you build with Xcode will last a year"
+                clean_profiles
                 break
                 ;;
             "Skip")

--- a/BuildLoopCaregiver.sh
+++ b/BuildLoopCaregiver.sh
@@ -292,6 +292,27 @@ function after_final_return_message() {
 # *** End of inlined file: inline_functions/before_final_return_message.sh ***
 
 
+# clean provisioning profiles saved on disk
+
+# *** Start of inlined file: inline_functions/clean_profiles.sh ***
+clean_profiles() {
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
+    # The path changed between Xcode 15 and Xcode 16, delete both locations
+    xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
+    xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+
+    if [[ -d "$xcode15_path" ]]; then
+        rm -rf "$xcode15_path"
+    fi
+    if [[ -d "$xcode16_path" ]]; then
+        rm -rf "$xcode16_path"
+    fi
+    echo -e "✅ Profiles are cleaned."
+}
+# *** End of inlined file: inline_functions/clean_profiles.sh ***
+
+
 ############################################################
 # Common functions used by multiple build scripts
 #    - Start of build_functions.sh common code

--- a/BuildLoopCaregiver.sh
+++ b/BuildLoopCaregiver.sh
@@ -364,7 +364,7 @@ LOWEST_XCODE_VER="15.4"
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
 LATEST_XCODE_VER="16.0"
 
-#This is the lowest version of macOS required to run LATEST_XCODE_VER
+#This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
@@ -382,7 +382,7 @@ function check_versions() {
     echo "Verifying Xcode and macOS versions..."
 
     if ! command -v xcodebuild >/dev/null; then
-        echo "Xcode not found. Please install Xcode and try again."
+        echo "  Xcode not found. Please install Xcode and try again."
         exit_or_return_menu
     fi
 
@@ -398,12 +398,15 @@ function check_versions() {
         MACOS_VER=$(sw_vers -productVersion)
     fi
 
-    echo "Xcode found: Version $XCODE_VER"
+    echo "  Xcode found: Version $XCODE_VER"
 
     # Check if Xcode version is greater than the latest known version
     if [ "$(compare_versions "$XCODE_VER" "$LATEST_XCODE_VER")" = "$LATEST_XCODE_VER" ] && [ "$XCODE_VER" != "$LATEST_XCODE_VER" ]; then
-        echo "You have a newer Xcode version ($XCODE_VER) than the latest known by this script ($LATEST_XCODE_VER)."
-        echo "Please verify your versions using https://www.loopandlearn.org/version-updates/ and https://developer.apple.com/support/xcode/"
+        echo ""
+        echo "You have a newer Xcode version ($XCODE_VER) than"
+        echo "  the latest released version known by this script ($LATEST_XCODE_VER)."
+        echo "You can probably continue; but if you have problems, refer to"
+        echo "    https://developer.apple.com/support/xcode/"
 
         options=("Continue" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
@@ -411,17 +414,25 @@ function check_versions() {
     # Check if Xcode version is less than the lowest required version
     elif [ "$(compare_versions "$XCODE_VER" "$LOWEST_XCODE_VER")" = "$XCODE_VER" ] && [ "$XCODE_VER" != "$LOWEST_XCODE_VER" ]; then
         if [ "$(compare_versions "$MACOS_VER" "$LOWEST_MACOS_VER")" != "$LOWEST_MACOS_VER" ]; then
-            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER. Please update macOS to version $LOWEST_MACOS_VER or later."
-            echo "If you can't update, follow the GitHub build option here: https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
+            echo ""
+            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER"
+            echo "  required to build for iOS $LATEST_IOS_VER."
+            echo "Please update macOS to version $LOWEST_MACOS_VER or later."
+            echo ""
+            echo "If you can't update, follow the GitHub build option here:"
+            echo "  https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
         fi
 
+        echo ""
         echo "You need to upgrade Xcode to version $LOWEST_XCODE_VER or later to build for iOS $LATEST_IOS_VER."
+        echo "If your iOS is at a lower version, refer to the compatibility table in LoopDocs"
+        echo "  https://loopkit.github.io/loopdocs/build/xcode-version/#compatible-versions"
 
         options=("Continue with lower iOS version" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
         menu_select "${options[@]}" "${actions[@]}"
     else 
-        echo "You have a Xcode version ($XCODE_VER) which can build for iOS $LATEST_IOS_VER."
+        echo "Your Xcode version can build up to iOS $LATEST_IOS_VER."
     fi
 }
 # *** End of inlined file: inline_functions/building_verify_version.sh ***

--- a/BuildLoopDev.sh
+++ b/BuildLoopDev.sh
@@ -295,13 +295,20 @@ function after_final_return_message() {
 # clean provisioning profiles saved on disk
 
 # *** Start of inlined file: inline_functions/clean_profiles.sh ***
+############################################################
+# clean_profiles function
+#   Action: deletes saved mobileprovisions from Mac
+#   Information:
+#     If Xcode is open, *.mobileprovisions are deleted and new ones generated
+#     The path changed between Xcode 15 and Xcode 16, delete both folders
+############################################################
+
 clean_profiles() {
-    echo -e "\n✅ Cleaning Profiles"
-    echo -e "     This ensures the next app you build with Xcode will last a year."
-    # The path changed between Xcode 15 and Xcode 16, delete both locations
     xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
     xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
 
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
     if [[ -d "$xcode15_path" ]]; then
         rm -rf "$xcode15_path"
     fi

--- a/BuildLoopDev.sh
+++ b/BuildLoopDev.sh
@@ -354,18 +354,18 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
-#This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.5"
+#This is the highest version we expect users to have on their iPhones
+LATEST_IOS_VER="18.0"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.3"
+LOWEST_XCODE_VER="15.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.4"
+LATEST_XCODE_VER="16.0"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
-LOWEST_MACOS_VER="14"
+LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
 # sorts them in ascending order using the sort command with the -V flag (version sorting),

--- a/BuildLoopDev.sh
+++ b/BuildLoopDev.sh
@@ -592,9 +592,7 @@ function ensure_a_year() {
     do
         case $opt in
             "Ensure a Year")
-                rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-                echo -e "✅ ${SUCCESS_FONT}Profiles were cleaned${NC}"
-                echo -e "   Next app you build with Xcode will last a year"
+                clean_profiles
                 break
                 ;;
             "Skip")

--- a/BuildLoopDev.sh
+++ b/BuildLoopDev.sh
@@ -292,6 +292,27 @@ function after_final_return_message() {
 # *** End of inlined file: inline_functions/before_final_return_message.sh ***
 
 
+# clean provisioning profiles saved on disk
+
+# *** Start of inlined file: inline_functions/clean_profiles.sh ***
+clean_profiles() {
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
+    # The path changed between Xcode 15 and Xcode 16, delete both locations
+    xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
+    xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+
+    if [[ -d "$xcode15_path" ]]; then
+        rm -rf "$xcode15_path"
+    fi
+    if [[ -d "$xcode16_path" ]]; then
+        rm -rf "$xcode16_path"
+    fi
+    echo -e "✅ Profiles are cleaned."
+}
+# *** End of inlined file: inline_functions/clean_profiles.sh ***
+
+
 ############################################################
 # Common functions used by multiple build scripts
 #    - Start of build_functions.sh common code

--- a/BuildLoopDev.sh
+++ b/BuildLoopDev.sh
@@ -364,7 +364,7 @@ LOWEST_XCODE_VER="15.4"
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
 LATEST_XCODE_VER="16.0"
 
-#This is the lowest version of macOS required to run LATEST_XCODE_VER
+#This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
@@ -382,7 +382,7 @@ function check_versions() {
     echo "Verifying Xcode and macOS versions..."
 
     if ! command -v xcodebuild >/dev/null; then
-        echo "Xcode not found. Please install Xcode and try again."
+        echo "  Xcode not found. Please install Xcode and try again."
         exit_or_return_menu
     fi
 
@@ -398,12 +398,15 @@ function check_versions() {
         MACOS_VER=$(sw_vers -productVersion)
     fi
 
-    echo "Xcode found: Version $XCODE_VER"
+    echo "  Xcode found: Version $XCODE_VER"
 
     # Check if Xcode version is greater than the latest known version
     if [ "$(compare_versions "$XCODE_VER" "$LATEST_XCODE_VER")" = "$LATEST_XCODE_VER" ] && [ "$XCODE_VER" != "$LATEST_XCODE_VER" ]; then
-        echo "You have a newer Xcode version ($XCODE_VER) than the latest known by this script ($LATEST_XCODE_VER)."
-        echo "Please verify your versions using https://www.loopandlearn.org/version-updates/ and https://developer.apple.com/support/xcode/"
+        echo ""
+        echo "You have a newer Xcode version ($XCODE_VER) than"
+        echo "  the latest released version known by this script ($LATEST_XCODE_VER)."
+        echo "You can probably continue; but if you have problems, refer to"
+        echo "    https://developer.apple.com/support/xcode/"
 
         options=("Continue" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
@@ -411,17 +414,25 @@ function check_versions() {
     # Check if Xcode version is less than the lowest required version
     elif [ "$(compare_versions "$XCODE_VER" "$LOWEST_XCODE_VER")" = "$XCODE_VER" ] && [ "$XCODE_VER" != "$LOWEST_XCODE_VER" ]; then
         if [ "$(compare_versions "$MACOS_VER" "$LOWEST_MACOS_VER")" != "$LOWEST_MACOS_VER" ]; then
-            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER. Please update macOS to version $LOWEST_MACOS_VER or later."
-            echo "If you can't update, follow the GitHub build option here: https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
+            echo ""
+            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER"
+            echo "  required to build for iOS $LATEST_IOS_VER."
+            echo "Please update macOS to version $LOWEST_MACOS_VER or later."
+            echo ""
+            echo "If you can't update, follow the GitHub build option here:"
+            echo "  https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
         fi
 
+        echo ""
         echo "You need to upgrade Xcode to version $LOWEST_XCODE_VER or later to build for iOS $LATEST_IOS_VER."
+        echo "If your iOS is at a lower version, refer to the compatibility table in LoopDocs"
+        echo "  https://loopkit.github.io/loopdocs/build/xcode-version/#compatible-versions"
 
         options=("Continue with lower iOS version" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
         menu_select "${options[@]}" "${actions[@]}"
     else 
-        echo "You have a Xcode version ($XCODE_VER) which can build for iOS $LATEST_IOS_VER."
+        echo "Your Xcode version can build up to iOS $LATEST_IOS_VER."
     fi
 }
 # *** End of inlined file: inline_functions/building_verify_version.sh ***

--- a/BuildLoopFollow.sh
+++ b/BuildLoopFollow.sh
@@ -355,18 +355,18 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
-#This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.5"
+#This is the highest version we expect users to have on their iPhones
+LATEST_IOS_VER="18.0"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.3"
+LOWEST_XCODE_VER="15.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.4"
+LATEST_XCODE_VER="16.0"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
-LOWEST_MACOS_VER="14"
+LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
 # sorts them in ascending order using the sort command with the -V flag (version sorting),
@@ -809,7 +809,7 @@ function loop_follow_display_name_config_override() {
     target_file="${BUILD_DIR}/${base_target_name}.xcconfig"
 
 
-    section_separator
+    section_divider
     # Check if the target (display_name) file exists
     if [ -f "$target_file" ]; then
         # If it exists, remove the file downloaded from repo

--- a/BuildLoopFollow.sh
+++ b/BuildLoopFollow.sh
@@ -593,9 +593,7 @@ function ensure_a_year() {
     do
         case $opt in
             "Ensure a Year")
-                rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-                echo -e "✅ ${SUCCESS_FONT}Profiles were cleaned${NC}"
-                echo -e "   Next app you build with Xcode will last a year"
+                clean_profiles
                 break
                 ;;
             "Skip")

--- a/BuildLoopFollow.sh
+++ b/BuildLoopFollow.sh
@@ -296,13 +296,20 @@ function after_final_return_message() {
 # clean provisioning profiles saved on disk
 
 # *** Start of inlined file: inline_functions/clean_profiles.sh ***
+############################################################
+# clean_profiles function
+#   Action: deletes saved mobileprovisions from Mac
+#   Information:
+#     If Xcode is open, *.mobileprovisions are deleted and new ones generated
+#     The path changed between Xcode 15 and Xcode 16, delete both folders
+############################################################
+
 clean_profiles() {
-    echo -e "\n✅ Cleaning Profiles"
-    echo -e "     This ensures the next app you build with Xcode will last a year."
-    # The path changed between Xcode 15 and Xcode 16, delete both locations
     xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
     xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
 
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
     if [[ -d "$xcode15_path" ]]; then
         rm -rf "$xcode15_path"
     fi

--- a/BuildLoopFollow.sh
+++ b/BuildLoopFollow.sh
@@ -365,7 +365,7 @@ LOWEST_XCODE_VER="15.4"
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
 LATEST_XCODE_VER="16.0"
 
-#This is the lowest version of macOS required to run LATEST_XCODE_VER
+#This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
@@ -383,7 +383,7 @@ function check_versions() {
     echo "Verifying Xcode and macOS versions..."
 
     if ! command -v xcodebuild >/dev/null; then
-        echo "Xcode not found. Please install Xcode and try again."
+        echo "  Xcode not found. Please install Xcode and try again."
         exit_or_return_menu
     fi
 
@@ -399,12 +399,15 @@ function check_versions() {
         MACOS_VER=$(sw_vers -productVersion)
     fi
 
-    echo "Xcode found: Version $XCODE_VER"
+    echo "  Xcode found: Version $XCODE_VER"
 
     # Check if Xcode version is greater than the latest known version
     if [ "$(compare_versions "$XCODE_VER" "$LATEST_XCODE_VER")" = "$LATEST_XCODE_VER" ] && [ "$XCODE_VER" != "$LATEST_XCODE_VER" ]; then
-        echo "You have a newer Xcode version ($XCODE_VER) than the latest known by this script ($LATEST_XCODE_VER)."
-        echo "Please verify your versions using https://www.loopandlearn.org/version-updates/ and https://developer.apple.com/support/xcode/"
+        echo ""
+        echo "You have a newer Xcode version ($XCODE_VER) than"
+        echo "  the latest released version known by this script ($LATEST_XCODE_VER)."
+        echo "You can probably continue; but if you have problems, refer to"
+        echo "    https://developer.apple.com/support/xcode/"
 
         options=("Continue" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
@@ -412,17 +415,25 @@ function check_versions() {
     # Check if Xcode version is less than the lowest required version
     elif [ "$(compare_versions "$XCODE_VER" "$LOWEST_XCODE_VER")" = "$XCODE_VER" ] && [ "$XCODE_VER" != "$LOWEST_XCODE_VER" ]; then
         if [ "$(compare_versions "$MACOS_VER" "$LOWEST_MACOS_VER")" != "$LOWEST_MACOS_VER" ]; then
-            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER. Please update macOS to version $LOWEST_MACOS_VER or later."
-            echo "If you can't update, follow the GitHub build option here: https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
+            echo ""
+            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER"
+            echo "  required to build for iOS $LATEST_IOS_VER."
+            echo "Please update macOS to version $LOWEST_MACOS_VER or later."
+            echo ""
+            echo "If you can't update, follow the GitHub build option here:"
+            echo "  https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
         fi
 
+        echo ""
         echo "You need to upgrade Xcode to version $LOWEST_XCODE_VER or later to build for iOS $LATEST_IOS_VER."
+        echo "If your iOS is at a lower version, refer to the compatibility table in LoopDocs"
+        echo "  https://loopkit.github.io/loopdocs/build/xcode-version/#compatible-versions"
 
         options=("Continue with lower iOS version" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
         menu_select "${options[@]}" "${actions[@]}"
     else 
-        echo "You have a Xcode version ($XCODE_VER) which can build for iOS $LATEST_IOS_VER."
+        echo "Your Xcode version can build up to iOS $LATEST_IOS_VER."
     fi
 }
 # *** End of inlined file: inline_functions/building_verify_version.sh ***

--- a/BuildLoopFollow.sh
+++ b/BuildLoopFollow.sh
@@ -293,6 +293,27 @@ function after_final_return_message() {
 # *** End of inlined file: inline_functions/before_final_return_message.sh ***
 
 
+# clean provisioning profiles saved on disk
+
+# *** Start of inlined file: inline_functions/clean_profiles.sh ***
+clean_profiles() {
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
+    # The path changed between Xcode 15 and Xcode 16, delete both locations
+    xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
+    xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+
+    if [[ -d "$xcode15_path" ]]; then
+        rm -rf "$xcode15_path"
+    fi
+    if [[ -d "$xcode16_path" ]]; then
+        rm -rf "$xcode16_path"
+    fi
+    echo -e "✅ Profiles are cleaned."
+}
+# *** End of inlined file: inline_functions/clean_profiles.sh ***
+
+
 ############################################################
 # Common functions used by multiple build scripts
 #    - Start of build_functions.sh common code

--- a/BuildLoopReleased.sh
+++ b/BuildLoopReleased.sh
@@ -295,13 +295,20 @@ function after_final_return_message() {
 # clean provisioning profiles saved on disk
 
 # *** Start of inlined file: inline_functions/clean_profiles.sh ***
+############################################################
+# clean_profiles function
+#   Action: deletes saved mobileprovisions from Mac
+#   Information:
+#     If Xcode is open, *.mobileprovisions are deleted and new ones generated
+#     The path changed between Xcode 15 and Xcode 16, delete both folders
+############################################################
+
 clean_profiles() {
-    echo -e "\n✅ Cleaning Profiles"
-    echo -e "     This ensures the next app you build with Xcode will last a year."
-    # The path changed between Xcode 15 and Xcode 16, delete both locations
     xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
     xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
 
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
     if [[ -d "$xcode15_path" ]]; then
         rm -rf "$xcode15_path"
     fi

--- a/BuildLoopReleased.sh
+++ b/BuildLoopReleased.sh
@@ -354,18 +354,18 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
-#This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.5"
+#This is the highest version we expect users to have on their iPhones
+LATEST_IOS_VER="18.0"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.3"
+LOWEST_XCODE_VER="15.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.4"
+LATEST_XCODE_VER="16.0"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
-LOWEST_MACOS_VER="14"
+LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
 # sorts them in ascending order using the sort command with the -V flag (version sorting),

--- a/BuildLoopReleased.sh
+++ b/BuildLoopReleased.sh
@@ -592,9 +592,7 @@ function ensure_a_year() {
     do
         case $opt in
             "Ensure a Year")
-                rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-                echo -e "✅ ${SUCCESS_FONT}Profiles were cleaned${NC}"
-                echo -e "   Next app you build with Xcode will last a year"
+                clean_profiles
                 break
                 ;;
             "Skip")

--- a/BuildLoopReleased.sh
+++ b/BuildLoopReleased.sh
@@ -292,6 +292,27 @@ function after_final_return_message() {
 # *** End of inlined file: inline_functions/before_final_return_message.sh ***
 
 
+# clean provisioning profiles saved on disk
+
+# *** Start of inlined file: inline_functions/clean_profiles.sh ***
+clean_profiles() {
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
+    # The path changed between Xcode 15 and Xcode 16, delete both locations
+    xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
+    xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+
+    if [[ -d "$xcode15_path" ]]; then
+        rm -rf "$xcode15_path"
+    fi
+    if [[ -d "$xcode16_path" ]]; then
+        rm -rf "$xcode16_path"
+    fi
+    echo -e "✅ Profiles are cleaned."
+}
+# *** End of inlined file: inline_functions/clean_profiles.sh ***
+
+
 ############################################################
 # Common functions used by multiple build scripts
 #    - Start of build_functions.sh common code

--- a/BuildLoopReleased.sh
+++ b/BuildLoopReleased.sh
@@ -364,7 +364,7 @@ LOWEST_XCODE_VER="15.4"
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
 LATEST_XCODE_VER="16.0"
 
-#This is the lowest version of macOS required to run LATEST_XCODE_VER
+#This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
@@ -382,7 +382,7 @@ function check_versions() {
     echo "Verifying Xcode and macOS versions..."
 
     if ! command -v xcodebuild >/dev/null; then
-        echo "Xcode not found. Please install Xcode and try again."
+        echo "  Xcode not found. Please install Xcode and try again."
         exit_or_return_menu
     fi
 
@@ -398,12 +398,15 @@ function check_versions() {
         MACOS_VER=$(sw_vers -productVersion)
     fi
 
-    echo "Xcode found: Version $XCODE_VER"
+    echo "  Xcode found: Version $XCODE_VER"
 
     # Check if Xcode version is greater than the latest known version
     if [ "$(compare_versions "$XCODE_VER" "$LATEST_XCODE_VER")" = "$LATEST_XCODE_VER" ] && [ "$XCODE_VER" != "$LATEST_XCODE_VER" ]; then
-        echo "You have a newer Xcode version ($XCODE_VER) than the latest known by this script ($LATEST_XCODE_VER)."
-        echo "Please verify your versions using https://www.loopandlearn.org/version-updates/ and https://developer.apple.com/support/xcode/"
+        echo ""
+        echo "You have a newer Xcode version ($XCODE_VER) than"
+        echo "  the latest released version known by this script ($LATEST_XCODE_VER)."
+        echo "You can probably continue; but if you have problems, refer to"
+        echo "    https://developer.apple.com/support/xcode/"
 
         options=("Continue" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
@@ -411,17 +414,25 @@ function check_versions() {
     # Check if Xcode version is less than the lowest required version
     elif [ "$(compare_versions "$XCODE_VER" "$LOWEST_XCODE_VER")" = "$XCODE_VER" ] && [ "$XCODE_VER" != "$LOWEST_XCODE_VER" ]; then
         if [ "$(compare_versions "$MACOS_VER" "$LOWEST_MACOS_VER")" != "$LOWEST_MACOS_VER" ]; then
-            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER. Please update macOS to version $LOWEST_MACOS_VER or later."
-            echo "If you can't update, follow the GitHub build option here: https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
+            echo ""
+            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER"
+            echo "  required to build for iOS $LATEST_IOS_VER."
+            echo "Please update macOS to version $LOWEST_MACOS_VER or later."
+            echo ""
+            echo "If you can't update, follow the GitHub build option here:"
+            echo "  https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
         fi
 
+        echo ""
         echo "You need to upgrade Xcode to version $LOWEST_XCODE_VER or later to build for iOS $LATEST_IOS_VER."
+        echo "If your iOS is at a lower version, refer to the compatibility table in LoopDocs"
+        echo "  https://loopkit.github.io/loopdocs/build/xcode-version/#compatible-versions"
 
         options=("Continue with lower iOS version" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
         menu_select "${options[@]}" "${actions[@]}"
     else 
-        echo "You have a Xcode version ($XCODE_VER) which can build for iOS $LATEST_IOS_VER."
+        echo "Your Xcode version can build up to iOS $LATEST_IOS_VER."
     fi
 }
 # *** End of inlined file: inline_functions/building_verify_version.sh ***

--- a/BuildSelectScript.sh
+++ b/BuildSelectScript.sh
@@ -264,7 +264,7 @@ function utility_scripts {
     echo -e "     * It can free up a substantial amount of disk space"
     echo -e " 4. Clean Profiles:"
     echo -e "     Deletes any provisioning profiles on your Mac"
-    echo -e "     * Next time you build, Xcode will generate a new one"
+    echo -e "     * Xcode will generate new ones"
     echo -e "     * Ensures the next app you build with Xcode will last a year"
     section_divider
     echo -e "${INFO_FONT}Pay attention - quit Xcode before selecting some options${NC}"
@@ -274,7 +274,7 @@ function utility_scripts {
         "Delete Old Downloads"
         "Clean Derived Data (Quit Xcode)"
         "Xcode Cleanup (Quit Xcode)"
-        "Clean Profiles (Quit Xcode)"
+        "Clean Profiles"
         "Return to Menu"
     )
     actions=(

--- a/BuildSelectScript.sh
+++ b/BuildSelectScript.sh
@@ -262,6 +262,7 @@ function utility_scripts {
     echo -e "     Clears more disk space filled up by using Xcode."
     echo -e "     * Use after uninstalling Xcode prior to new installation"
     echo -e "     * It can free up a substantial amount of disk space"
+    echo -e "     You should quit Xcode before running this script."
     echo -e " 4. Clean Profiles:"
     echo -e "     Deletes any provisioning profiles on your Mac"
     echo -e "     * Xcode will generate new ones"

--- a/BuildTrio.sh
+++ b/BuildTrio.sh
@@ -365,18 +365,18 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
-#This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.5"
+#This is the highest version we expect users to have on their iPhones
+LATEST_IOS_VER="18.0"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.3"
+LOWEST_XCODE_VER="15.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.4"
+LATEST_XCODE_VER="16.0"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
-LOWEST_MACOS_VER="14"
+LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
 # sorts them in ascending order using the sort command with the -V flag (version sorting),

--- a/BuildTrio.sh
+++ b/BuildTrio.sh
@@ -306,13 +306,20 @@ function after_final_return_message() {
 # clean provisioning profiles saved on disk
 
 # *** Start of inlined file: inline_functions/clean_profiles.sh ***
+############################################################
+# clean_profiles function
+#   Action: deletes saved mobileprovisions from Mac
+#   Information:
+#     If Xcode is open, *.mobileprovisions are deleted and new ones generated
+#     The path changed between Xcode 15 and Xcode 16, delete both folders
+############################################################
+
 clean_profiles() {
-    echo -e "\n✅ Cleaning Profiles"
-    echo -e "     This ensures the next app you build with Xcode will last a year."
-    # The path changed between Xcode 15 and Xcode 16, delete both locations
     xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
     xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
 
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
     if [[ -d "$xcode15_path" ]]; then
         rm -rf "$xcode15_path"
     fi

--- a/BuildTrio.sh
+++ b/BuildTrio.sh
@@ -375,7 +375,7 @@ LOWEST_XCODE_VER="15.4"
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
 LATEST_XCODE_VER="16.0"
 
-#This is the lowest version of macOS required to run LATEST_XCODE_VER
+#This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
@@ -393,7 +393,7 @@ function check_versions() {
     echo "Verifying Xcode and macOS versions..."
 
     if ! command -v xcodebuild >/dev/null; then
-        echo "Xcode not found. Please install Xcode and try again."
+        echo "  Xcode not found. Please install Xcode and try again."
         exit_or_return_menu
     fi
 
@@ -409,12 +409,15 @@ function check_versions() {
         MACOS_VER=$(sw_vers -productVersion)
     fi
 
-    echo "Xcode found: Version $XCODE_VER"
+    echo "  Xcode found: Version $XCODE_VER"
 
     # Check if Xcode version is greater than the latest known version
     if [ "$(compare_versions "$XCODE_VER" "$LATEST_XCODE_VER")" = "$LATEST_XCODE_VER" ] && [ "$XCODE_VER" != "$LATEST_XCODE_VER" ]; then
-        echo "You have a newer Xcode version ($XCODE_VER) than the latest known by this script ($LATEST_XCODE_VER)."
-        echo "Please verify your versions using https://www.loopandlearn.org/version-updates/ and https://developer.apple.com/support/xcode/"
+        echo ""
+        echo "You have a newer Xcode version ($XCODE_VER) than"
+        echo "  the latest released version known by this script ($LATEST_XCODE_VER)."
+        echo "You can probably continue; but if you have problems, refer to"
+        echo "    https://developer.apple.com/support/xcode/"
 
         options=("Continue" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
@@ -422,17 +425,25 @@ function check_versions() {
     # Check if Xcode version is less than the lowest required version
     elif [ "$(compare_versions "$XCODE_VER" "$LOWEST_XCODE_VER")" = "$XCODE_VER" ] && [ "$XCODE_VER" != "$LOWEST_XCODE_VER" ]; then
         if [ "$(compare_versions "$MACOS_VER" "$LOWEST_MACOS_VER")" != "$LOWEST_MACOS_VER" ]; then
-            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER. Please update macOS to version $LOWEST_MACOS_VER or later."
-            echo "If you can't update, follow the GitHub build option here: https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
+            echo ""
+            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER"
+            echo "  required to build for iOS $LATEST_IOS_VER."
+            echo "Please update macOS to version $LOWEST_MACOS_VER or later."
+            echo ""
+            echo "If you can't update, follow the GitHub build option here:"
+            echo "  https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
         fi
 
+        echo ""
         echo "You need to upgrade Xcode to version $LOWEST_XCODE_VER or later to build for iOS $LATEST_IOS_VER."
+        echo "If your iOS is at a lower version, refer to the compatibility table in LoopDocs"
+        echo "  https://loopkit.github.io/loopdocs/build/xcode-version/#compatible-versions"
 
         options=("Continue with lower iOS version" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
         menu_select "${options[@]}" "${actions[@]}"
     else 
-        echo "You have a Xcode version ($XCODE_VER) which can build for iOS $LATEST_IOS_VER."
+        echo "Your Xcode version can build up to iOS $LATEST_IOS_VER."
     fi
 }
 # *** End of inlined file: inline_functions/building_verify_version.sh ***

--- a/BuildTrio.sh
+++ b/BuildTrio.sh
@@ -303,6 +303,27 @@ function after_final_return_message() {
 # *** End of inlined file: inline_functions/before_final_return_message.sh ***
 
 
+# clean provisioning profiles saved on disk
+
+# *** Start of inlined file: inline_functions/clean_profiles.sh ***
+clean_profiles() {
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
+    # The path changed between Xcode 15 and Xcode 16, delete both locations
+    xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
+    xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+
+    if [[ -d "$xcode15_path" ]]; then
+        rm -rf "$xcode15_path"
+    fi
+    if [[ -d "$xcode16_path" ]]; then
+        rm -rf "$xcode16_path"
+    fi
+    echo -e "✅ Profiles are cleaned."
+}
+# *** End of inlined file: inline_functions/clean_profiles.sh ***
+
+
 ############################################################
 # Common functions used by multiple build scripts
 #    - Start of build_functions.sh common code

--- a/BuildTrio.sh
+++ b/BuildTrio.sh
@@ -603,9 +603,7 @@ function ensure_a_year() {
     do
         case $opt in
             "Ensure a Year")
-                rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-                echo -e "✅ ${SUCCESS_FONT}Profiles were cleaned${NC}"
-                echo -e "   Next app you build with Xcode will last a year"
+                clean_profiles
                 break
                 ;;
             "Skip")

--- a/Build_iAPS.sh
+++ b/Build_iAPS.sh
@@ -300,6 +300,27 @@ function after_final_return_message() {
 # *** End of inlined file: inline_functions/before_final_return_message.sh ***
 
 
+# clean provisioning profiles saved on disk
+
+# *** Start of inlined file: inline_functions/clean_profiles.sh ***
+clean_profiles() {
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
+    # The path changed between Xcode 15 and Xcode 16, delete both locations
+    xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
+    xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+
+    if [[ -d "$xcode15_path" ]]; then
+        rm -rf "$xcode15_path"
+    fi
+    if [[ -d "$xcode16_path" ]]; then
+        rm -rf "$xcode16_path"
+    fi
+    echo -e "✅ Profiles are cleaned."
+}
+# *** End of inlined file: inline_functions/clean_profiles.sh ***
+
+
 ############################################################
 # Common functions used by multiple build scripts
 #    - Start of build_functions.sh common code

--- a/Build_iAPS.sh
+++ b/Build_iAPS.sh
@@ -600,9 +600,7 @@ function ensure_a_year() {
     do
         case $opt in
             "Ensure a Year")
-                rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-                echo -e "✅ ${SUCCESS_FONT}Profiles were cleaned${NC}"
-                echo -e "   Next app you build with Xcode will last a year"
+                clean_profiles
                 break
                 ;;
             "Skip")

--- a/Build_iAPS.sh
+++ b/Build_iAPS.sh
@@ -303,13 +303,20 @@ function after_final_return_message() {
 # clean provisioning profiles saved on disk
 
 # *** Start of inlined file: inline_functions/clean_profiles.sh ***
+############################################################
+# clean_profiles function
+#   Action: deletes saved mobileprovisions from Mac
+#   Information:
+#     If Xcode is open, *.mobileprovisions are deleted and new ones generated
+#     The path changed between Xcode 15 and Xcode 16, delete both folders
+############################################################
+
 clean_profiles() {
-    echo -e "\n✅ Cleaning Profiles"
-    echo -e "     This ensures the next app you build with Xcode will last a year."
-    # The path changed between Xcode 15 and Xcode 16, delete both locations
     xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
     xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
 
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
     if [[ -d "$xcode15_path" ]]; then
         rm -rf "$xcode15_path"
     fi
@@ -799,7 +806,7 @@ function utility_scripts {
     echo -e "     * It can free up a substantial amount of disk space"
     echo -e " 4. Clean Profiles:"
     echo -e "     Deletes any provisioning profiles on your Mac"
-    echo -e "     * Next time you build, Xcode will generate a new one"
+    echo -e "     * Xcode will generate new ones"
     echo -e "     * Ensures the next app you build with Xcode will last a year"
     section_divider
     echo -e "${INFO_FONT}Pay attention - quit Xcode before selecting some options${NC}"
@@ -809,7 +816,7 @@ function utility_scripts {
         "Delete Old Downloads"
         "Clean Derived Data (Quit Xcode)"
         "Xcode Cleanup (Quit Xcode)"
-        "Clean Profiles (Quit Xcode)"
+        "Clean Profiles"
         "Return to Menu"
     )
     actions=(

--- a/Build_iAPS.sh
+++ b/Build_iAPS.sh
@@ -372,7 +372,7 @@ LOWEST_XCODE_VER="15.4"
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
 LATEST_XCODE_VER="16.0"
 
-#This is the lowest version of macOS required to run LATEST_XCODE_VER
+#This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
@@ -390,7 +390,7 @@ function check_versions() {
     echo "Verifying Xcode and macOS versions..."
 
     if ! command -v xcodebuild >/dev/null; then
-        echo "Xcode not found. Please install Xcode and try again."
+        echo "  Xcode not found. Please install Xcode and try again."
         exit_or_return_menu
     fi
 
@@ -406,12 +406,15 @@ function check_versions() {
         MACOS_VER=$(sw_vers -productVersion)
     fi
 
-    echo "Xcode found: Version $XCODE_VER"
+    echo "  Xcode found: Version $XCODE_VER"
 
     # Check if Xcode version is greater than the latest known version
     if [ "$(compare_versions "$XCODE_VER" "$LATEST_XCODE_VER")" = "$LATEST_XCODE_VER" ] && [ "$XCODE_VER" != "$LATEST_XCODE_VER" ]; then
-        echo "You have a newer Xcode version ($XCODE_VER) than the latest known by this script ($LATEST_XCODE_VER)."
-        echo "Please verify your versions using https://www.loopandlearn.org/version-updates/ and https://developer.apple.com/support/xcode/"
+        echo ""
+        echo "You have a newer Xcode version ($XCODE_VER) than"
+        echo "  the latest released version known by this script ($LATEST_XCODE_VER)."
+        echo "You can probably continue; but if you have problems, refer to"
+        echo "    https://developer.apple.com/support/xcode/"
 
         options=("Continue" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
@@ -419,17 +422,25 @@ function check_versions() {
     # Check if Xcode version is less than the lowest required version
     elif [ "$(compare_versions "$XCODE_VER" "$LOWEST_XCODE_VER")" = "$XCODE_VER" ] && [ "$XCODE_VER" != "$LOWEST_XCODE_VER" ]; then
         if [ "$(compare_versions "$MACOS_VER" "$LOWEST_MACOS_VER")" != "$LOWEST_MACOS_VER" ]; then
-            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER. Please update macOS to version $LOWEST_MACOS_VER or later."
-            echo "If you can't update, follow the GitHub build option here: https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
+            echo ""
+            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER"
+            echo "  required to build for iOS $LATEST_IOS_VER."
+            echo "Please update macOS to version $LOWEST_MACOS_VER or later."
+            echo ""
+            echo "If you can't update, follow the GitHub build option here:"
+            echo "  https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
         fi
 
+        echo ""
         echo "You need to upgrade Xcode to version $LOWEST_XCODE_VER or later to build for iOS $LATEST_IOS_VER."
+        echo "If your iOS is at a lower version, refer to the compatibility table in LoopDocs"
+        echo "  https://loopkit.github.io/loopdocs/build/xcode-version/#compatible-versions"
 
         options=("Continue with lower iOS version" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
         menu_select "${options[@]}" "${actions[@]}"
     else 
-        echo "You have a Xcode version ($XCODE_VER) which can build for iOS $LATEST_IOS_VER."
+        echo "Your Xcode version can build up to iOS $LATEST_IOS_VER."
     fi
 }
 # *** End of inlined file: inline_functions/building_verify_version.sh ***

--- a/Build_iAPS.sh
+++ b/Build_iAPS.sh
@@ -804,6 +804,7 @@ function utility_scripts {
     echo -e "     Clears more disk space filled up by using Xcode."
     echo -e "     * Use after uninstalling Xcode prior to new installation"
     echo -e "     * It can free up a substantial amount of disk space"
+    echo -e "     You should quit Xcode before running this script."
     echo -e " 4. Clean Profiles:"
     echo -e "     Deletes any provisioning profiles on your Mac"
     echo -e "     * Xcode will generate new ones"

--- a/Build_iAPS.sh
+++ b/Build_iAPS.sh
@@ -362,18 +362,18 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
-#This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.5"
+#This is the highest version we expect users to have on their iPhones
+LATEST_IOS_VER="18.0"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.3"
+LOWEST_XCODE_VER="15.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.4"
+LATEST_XCODE_VER="16.0"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
-LOWEST_MACOS_VER="14"
+LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
 # sorts them in ascending order using the sort command with the -V flag (version sorting),

--- a/BuildxDrip4iOS.sh
+++ b/BuildxDrip4iOS.sh
@@ -300,6 +300,27 @@ function after_final_return_message() {
 # *** End of inlined file: inline_functions/before_final_return_message.sh ***
 
 
+# clean provisioning profiles saved on disk
+
+# *** Start of inlined file: inline_functions/clean_profiles.sh ***
+clean_profiles() {
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
+    # The path changed between Xcode 15 and Xcode 16, delete both locations
+    xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
+    xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+
+    if [[ -d "$xcode15_path" ]]; then
+        rm -rf "$xcode15_path"
+    fi
+    if [[ -d "$xcode16_path" ]]; then
+        rm -rf "$xcode16_path"
+    fi
+    echo -e "✅ Profiles are cleaned."
+}
+# *** End of inlined file: inline_functions/clean_profiles.sh ***
+
+
 ############################################################
 # Common functions used by multiple build scripts
 #    - Start of build_functions.sh common code

--- a/BuildxDrip4iOS.sh
+++ b/BuildxDrip4iOS.sh
@@ -600,9 +600,7 @@ function ensure_a_year() {
     do
         case $opt in
             "Ensure a Year")
-                rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-                echo -e "✅ ${SUCCESS_FONT}Profiles were cleaned${NC}"
-                echo -e "   Next app you build with Xcode will last a year"
+                clean_profiles
                 break
                 ;;
             "Skip")

--- a/BuildxDrip4iOS.sh
+++ b/BuildxDrip4iOS.sh
@@ -303,13 +303,20 @@ function after_final_return_message() {
 # clean provisioning profiles saved on disk
 
 # *** Start of inlined file: inline_functions/clean_profiles.sh ***
+############################################################
+# clean_profiles function
+#   Action: deletes saved mobileprovisions from Mac
+#   Information:
+#     If Xcode is open, *.mobileprovisions are deleted and new ones generated
+#     The path changed between Xcode 15 and Xcode 16, delete both folders
+############################################################
+
 clean_profiles() {
-    echo -e "\n✅ Cleaning Profiles"
-    echo -e "     This ensures the next app you build with Xcode will last a year."
-    # The path changed between Xcode 15 and Xcode 16, delete both locations
     xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
     xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
 
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
     if [[ -d "$xcode15_path" ]]; then
         rm -rf "$xcode15_path"
     fi

--- a/BuildxDrip4iOS.sh
+++ b/BuildxDrip4iOS.sh
@@ -372,7 +372,7 @@ LOWEST_XCODE_VER="15.4"
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
 LATEST_XCODE_VER="16.0"
 
-#This is the lowest version of macOS required to run LATEST_XCODE_VER
+#This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
@@ -390,7 +390,7 @@ function check_versions() {
     echo "Verifying Xcode and macOS versions..."
 
     if ! command -v xcodebuild >/dev/null; then
-        echo "Xcode not found. Please install Xcode and try again."
+        echo "  Xcode not found. Please install Xcode and try again."
         exit_or_return_menu
     fi
 
@@ -406,12 +406,15 @@ function check_versions() {
         MACOS_VER=$(sw_vers -productVersion)
     fi
 
-    echo "Xcode found: Version $XCODE_VER"
+    echo "  Xcode found: Version $XCODE_VER"
 
     # Check if Xcode version is greater than the latest known version
     if [ "$(compare_versions "$XCODE_VER" "$LATEST_XCODE_VER")" = "$LATEST_XCODE_VER" ] && [ "$XCODE_VER" != "$LATEST_XCODE_VER" ]; then
-        echo "You have a newer Xcode version ($XCODE_VER) than the latest known by this script ($LATEST_XCODE_VER)."
-        echo "Please verify your versions using https://www.loopandlearn.org/version-updates/ and https://developer.apple.com/support/xcode/"
+        echo ""
+        echo "You have a newer Xcode version ($XCODE_VER) than"
+        echo "  the latest released version known by this script ($LATEST_XCODE_VER)."
+        echo "You can probably continue; but if you have problems, refer to"
+        echo "    https://developer.apple.com/support/xcode/"
 
         options=("Continue" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
@@ -419,17 +422,25 @@ function check_versions() {
     # Check if Xcode version is less than the lowest required version
     elif [ "$(compare_versions "$XCODE_VER" "$LOWEST_XCODE_VER")" = "$XCODE_VER" ] && [ "$XCODE_VER" != "$LOWEST_XCODE_VER" ]; then
         if [ "$(compare_versions "$MACOS_VER" "$LOWEST_MACOS_VER")" != "$LOWEST_MACOS_VER" ]; then
-            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER. Please update macOS to version $LOWEST_MACOS_VER or later."
-            echo "If you can't update, follow the GitHub build option here: https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
+            echo ""
+            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER"
+            echo "  required to build for iOS $LATEST_IOS_VER."
+            echo "Please update macOS to version $LOWEST_MACOS_VER or later."
+            echo ""
+            echo "If you can't update, follow the GitHub build option here:"
+            echo "  https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
         fi
 
+        echo ""
         echo "You need to upgrade Xcode to version $LOWEST_XCODE_VER or later to build for iOS $LATEST_IOS_VER."
+        echo "If your iOS is at a lower version, refer to the compatibility table in LoopDocs"
+        echo "  https://loopkit.github.io/loopdocs/build/xcode-version/#compatible-versions"
 
         options=("Continue with lower iOS version" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
         menu_select "${options[@]}" "${actions[@]}"
     else 
-        echo "You have a Xcode version ($XCODE_VER) which can build for iOS $LATEST_IOS_VER."
+        echo "Your Xcode version can build up to iOS $LATEST_IOS_VER."
     fi
 }
 # *** End of inlined file: inline_functions/building_verify_version.sh ***

--- a/BuildxDrip4iOS.sh
+++ b/BuildxDrip4iOS.sh
@@ -362,18 +362,18 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
-#This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.5"
+#This is the highest version we expect users to have on their iPhones
+LATEST_IOS_VER="18.0"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.3"
+LOWEST_XCODE_VER="15.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.4"
+LATEST_XCODE_VER="16.0"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
-LOWEST_MACOS_VER="14"
+LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
 # sorts them in ascending order using the sort command with the -V flag (version sorting),

--- a/CleanProfiles.sh
+++ b/CleanProfiles.sh
@@ -165,13 +165,20 @@ function erase_previous_line {
 
 
 # *** Start of inlined file: inline_functions/clean_profiles.sh ***
+############################################################
+# clean_profiles function
+#   Action: deletes saved mobileprovisions from Mac
+#   Information:
+#     If Xcode is open, *.mobileprovisions are deleted and new ones generated
+#     The path changed between Xcode 15 and Xcode 16, delete both folders
+############################################################
+
 clean_profiles() {
-    echo -e "\n✅ Cleaning Profiles"
-    echo -e "     This ensures the next app you build with Xcode will last a year."
-    # The path changed between Xcode 15 and Xcode 16, delete both locations
     xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
     xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
 
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
     if [[ -d "$xcode15_path" ]]; then
         rm -rf "$xcode15_path"
     fi

--- a/CleanProfiles.sh
+++ b/CleanProfiles.sh
@@ -163,12 +163,28 @@ function erase_previous_line {
 # *** End of inlined file: inline_functions/common.sh ***
 
 
+
+# *** Start of inlined file: inline_functions/clean_profiles.sh ***
+clean_profiles() {
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
+    # The path changed between Xcode 15 and Xcode 16, delete both locations
+    xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
+    xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+
+    if [[ -d "$xcode15_path" ]]; then
+        rm -rf "$xcode15_path"
+    fi
+    if [[ -d "$xcode16_path" ]]; then
+        rm -rf "$xcode16_path"
+    fi
+    echo -e "✅ Profiles are cleaned."
+}
+# *** End of inlined file: inline_functions/clean_profiles.sh ***
+
+
 section_separator
-echo -e "${INFO_FONT}If you did not quit Xcode before selecting, you might see errors${NC}"
-echo -e "\n✅ Cleaning Profiles"
-echo -e " - this ensures the next app you build with Xcode will last a year.\n"
-rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-echo -e "✅ Profiles are cleaned."
+clean_profiles
 exit_script
 # *** End of inlined file: src/CleanProfiles.sh ***
 

--- a/TrioBuildSelectScript.sh
+++ b/TrioBuildSelectScript.sh
@@ -264,7 +264,7 @@ function utility_scripts {
     echo -e "     * It can free up a substantial amount of disk space"
     echo -e " 4. Clean Profiles:"
     echo -e "     Deletes any provisioning profiles on your Mac"
-    echo -e "     * Next time you build, Xcode will generate a new one"
+    echo -e "     * Xcode will generate new ones"
     echo -e "     * Ensures the next app you build with Xcode will last a year"
     section_divider
     echo -e "${INFO_FONT}Pay attention - quit Xcode before selecting some options${NC}"
@@ -274,7 +274,7 @@ function utility_scripts {
         "Delete Old Downloads"
         "Clean Derived Data (Quit Xcode)"
         "Xcode Cleanup (Quit Xcode)"
-        "Clean Profiles (Quit Xcode)"
+        "Clean Profiles"
         "Return to Menu"
     )
     actions=(

--- a/TrioBuildSelectScript.sh
+++ b/TrioBuildSelectScript.sh
@@ -262,6 +262,7 @@ function utility_scripts {
     echo -e "     Clears more disk space filled up by using Xcode."
     echo -e "     * Use after uninstalling Xcode prior to new installation"
     echo -e "     * It can free up a substantial amount of disk space"
+    echo -e "     You should quit Xcode before running this script."
     echo -e " 4. Clean Profiles:"
     echo -e "     Deletes any provisioning profiles on your Mac"
     echo -e "     * Xcode will generate new ones"

--- a/inline_functions/build_functions.sh
+++ b/inline_functions/build_functions.sh
@@ -97,9 +97,7 @@ function ensure_a_year() {
     do
         case $opt in
             "Ensure a Year")
-                rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-                echo -e "✅ ${SUCCESS_FONT}Profiles were cleaned${NC}"
-                echo -e "   Next app you build with Xcode will last a year"
+                clean_profiles
                 break
                 ;;
             "Skip")

--- a/inline_functions/build_functions.sh
+++ b/inline_functions/build_functions.sh
@@ -37,6 +37,9 @@
 # Messages prior to opening xcode
 #!inline before_final_return_message.sh
 
+# clean provisioning profiles saved on disk
+#!inline clean_profiles.sh
+
 ############################################################
 # Common functions used by multiple build scripts
 #    - Start of build_functions.sh common code

--- a/inline_functions/building_verify_version.sh
+++ b/inline_functions/building_verify_version.sh
@@ -9,7 +9,7 @@ LOWEST_XCODE_VER="15.4"
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
 LATEST_XCODE_VER="16.0"
 
-#This is the lowest version of macOS required to run LATEST_XCODE_VER
+#This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
@@ -27,7 +27,7 @@ function check_versions() {
     echo "Verifying Xcode and macOS versions..."
 
     if ! command -v xcodebuild >/dev/null; then
-        echo "Xcode not found. Please install Xcode and try again."
+        echo "  Xcode not found. Please install Xcode and try again."
         exit_or_return_menu
     fi
 
@@ -43,12 +43,15 @@ function check_versions() {
         MACOS_VER=$(sw_vers -productVersion)
     fi
 
-    echo "Xcode found: Version $XCODE_VER"
+    echo "  Xcode found: Version $XCODE_VER"
 
     # Check if Xcode version is greater than the latest known version
     if [ "$(compare_versions "$XCODE_VER" "$LATEST_XCODE_VER")" = "$LATEST_XCODE_VER" ] && [ "$XCODE_VER" != "$LATEST_XCODE_VER" ]; then
-        echo "You have a newer Xcode version ($XCODE_VER) than the latest known by this script ($LATEST_XCODE_VER)."
-        echo "Please verify your versions using https://www.loopandlearn.org/version-updates/ and https://developer.apple.com/support/xcode/"
+        echo ""
+        echo "You have a newer Xcode version ($XCODE_VER) than"
+        echo "  the latest released version known by this script ($LATEST_XCODE_VER)."
+        echo "You can probably continue; but if you have problems, refer to"
+        echo "    https://developer.apple.com/support/xcode/"
 
         options=("Continue" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
@@ -56,16 +59,24 @@ function check_versions() {
     # Check if Xcode version is less than the lowest required version
     elif [ "$(compare_versions "$XCODE_VER" "$LOWEST_XCODE_VER")" = "$XCODE_VER" ] && [ "$XCODE_VER" != "$LOWEST_XCODE_VER" ]; then
         if [ "$(compare_versions "$MACOS_VER" "$LOWEST_MACOS_VER")" != "$LOWEST_MACOS_VER" ]; then
-            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER. Please update macOS to version $LOWEST_MACOS_VER or later."
-            echo "If you can't update, follow the GitHub build option here: https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
+            echo ""
+            echo "Your macOS version ($MACOS_VER) is lower than $LOWEST_MACOS_VER"
+            echo "  required to build for iOS $LATEST_IOS_VER."
+            echo "Please update macOS to version $LOWEST_MACOS_VER or later."
+            echo ""
+            echo "If you can't update, follow the GitHub build option here:"
+            echo "  https://loopkit.github.io/loopdocs/gh-actions/gh-overview/"
         fi
 
+        echo ""
         echo "You need to upgrade Xcode to version $LOWEST_XCODE_VER or later to build for iOS $LATEST_IOS_VER."
+        echo "If your iOS is at a lower version, refer to the compatibility table in LoopDocs"
+        echo "  https://loopkit.github.io/loopdocs/build/xcode-version/#compatible-versions"
 
         options=("Continue with lower iOS version" "$(exit_or_return_menu)")
         actions=("return" "exit_script")
         menu_select "${options[@]}" "${actions[@]}"
     else 
-        echo "You have a Xcode version ($XCODE_VER) which can build for iOS $LATEST_IOS_VER."
+        echo "Your Xcode version can build up to iOS $LATEST_IOS_VER."
     fi
 }

--- a/inline_functions/building_verify_version.sh
+++ b/inline_functions/building_verify_version.sh
@@ -1,16 +1,16 @@
 #This should be the latest iOS version
-#This is the version we expect users to have on their iPhones
-LATEST_IOS_VER="17.5"
+#This is the highest version we expect users to have on their iPhones
+LATEST_IOS_VER="18.0"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
-LOWEST_XCODE_VER="15.3"
+LOWEST_XCODE_VER="15.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="15.4"
+LATEST_XCODE_VER="16.0"
 
 #This is the lowest version of macOS required to run LATEST_XCODE_VER
-LOWEST_MACOS_VER="14"
+LOWEST_MACOS_VER="14.6"
 
 # The compare_versions function takes two version strings as input arguments,
 # sorts them in ascending order using the sort command with the -V flag (version sorting),

--- a/inline_functions/clean_profiles.sh
+++ b/inline_functions/clean_profiles.sh
@@ -1,0 +1,15 @@
+clean_profiles() {
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
+    # The path changed between Xcode 15 and Xcode 16, delete both locations
+    xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
+    xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+
+    if [[ -d "$xcode15_path" ]]; then
+        rm -rf "$xcode15_path"
+    fi
+    if [[ -d "$xcode16_path" ]]; then
+        rm -rf "$xcode16_path"
+    fi
+    echo -e "✅ Profiles are cleaned."
+}

--- a/inline_functions/clean_profiles.sh
+++ b/inline_functions/clean_profiles.sh
@@ -1,10 +1,17 @@
+############################################################
+# clean_profiles function
+#   Action: deletes saved mobileprovisions from Mac
+#   Information:
+#     If Xcode is open, *.mobileprovisions are deleted and new ones generated
+#     The path changed between Xcode 15 and Xcode 16, delete both folders
+############################################################
+
 clean_profiles() {
-    echo -e "\n✅ Cleaning Profiles"
-    echo -e "     This ensures the next app you build with Xcode will last a year."
-    # The path changed between Xcode 15 and Xcode 16, delete both locations
     xcode15_path=${HOME}/Library/MobileDevice/Provisioning\ Profiles
     xcode16_path=${HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles
 
+    echo -e "\n✅ Cleaning Profiles"
+    echo -e "     This ensures the next app you build with Xcode will last a year."
     if [[ -d "$xcode15_path" ]]; then
         rm -rf "$xcode15_path"
     fi

--- a/inline_functions/loopfollow_functions.sh
+++ b/inline_functions/loopfollow_functions.sh
@@ -42,7 +42,7 @@ function loop_follow_display_name_config_override() {
     target_file="${BUILD_DIR}/${base_target_name}.xcconfig"
 
 
-    section_separator
+    section_divider
     # Check if the target (display_name) file exists
     if [ -f "$target_file" ]; then
         # If it exists, remove the file downloaded from repo

--- a/inline_functions/utility_scripts.sh
+++ b/inline_functions/utility_scripts.sh
@@ -12,6 +12,7 @@ function utility_scripts {
     echo -e "     Clears more disk space filled up by using Xcode."
     echo -e "     * Use after uninstalling Xcode prior to new installation"
     echo -e "     * It can free up a substantial amount of disk space"
+    echo -e "     You should quit Xcode before running this script."
     echo -e " 4. Clean Profiles:"
     echo -e "     Deletes any provisioning profiles on your Mac"
     echo -e "     * Xcode will generate new ones"

--- a/inline_functions/utility_scripts.sh
+++ b/inline_functions/utility_scripts.sh
@@ -14,7 +14,7 @@ function utility_scripts {
     echo -e "     * It can free up a substantial amount of disk space"
     echo -e " 4. Clean Profiles:"
     echo -e "     Deletes any provisioning profiles on your Mac"
-    echo -e "     * Next time you build, Xcode will generate a new one"
+    echo -e "     * Xcode will generate new ones"
     echo -e "     * Ensures the next app you build with Xcode will last a year"
     section_divider
     echo -e "${INFO_FONT}Pay attention - quit Xcode before selecting some options${NC}"
@@ -24,7 +24,7 @@ function utility_scripts {
         "Delete Old Downloads"
         "Clean Derived Data (Quit Xcode)"
         "Xcode Cleanup (Quit Xcode)"
-        "Clean Profiles (Quit Xcode)"
+        "Clean Profiles"
         "Return to Menu"
     )
     actions=(

--- a/src/CleanProfiles.sh
+++ b/src/CleanProfiles.sh
@@ -2,10 +2,8 @@
 
 #!inline common.sh
 
+#!inline clean_profiles.sh
+
 section_separator
-echo -e "${INFO_FONT}If you did not quit Xcode before selecting, you might see errors${NC}"
-echo -e "\n✅ Cleaning Profiles"
-echo -e " - this ensures the next app you build with Xcode will last a year.\n"
-rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-echo -e "✅ Profiles are cleaned."
+clean_profiles
 exit_script


### PR DESCRIPTION
Modify the clean profile procedure to handle modified path for Xcode 16.
Update the min/max versions for Xcode, macOS and iOS.
Modify some language to make version messages easier to understand.