### PR TITLE
update lightly tested SHA for loop-dev

### DIFF
--- a/BuildLoopDev.sh
+++ b/BuildLoopDev.sh
@@ -794,8 +794,8 @@ open_source_warning
 ############################################################
 
 # Stable Dev SHA
-FIXED_SHA="3542408"
-FIXED_COMMIT_DATE="2024-Jul-06"
+FIXED_SHA="a32a19d"
+FIXED_COMMIT_DATE="2024-Aug-21"
 FLAG_USE_SHA=0
 
 URL_THIS_SCRIPT="https://github.com/LoopKit/LoopWorkspace.git"

--- a/src/BuildLoopDev.sh
+++ b/src/BuildLoopDev.sh
@@ -24,8 +24,8 @@ open_source_warning
 ############################################################
 
 # Stable Dev SHA
-FIXED_SHA="3542408"
-FIXED_COMMIT_DATE="2024-Jul-06"
+FIXED_SHA="a32a19d"
+FIXED_COMMIT_DATE="2024-Aug-21"
 FLAG_USE_SHA=0
 
 URL_THIS_SCRIPT="https://github.com/LoopKit/LoopWorkspace.git"


### PR DESCRIPTION
Update lightly tested SHA to the most recent value (at time of the PR).
This version is still essentially the same as main, 3.4.1, but has the following fixes for these submodules:

* CGMBLEKit: Add ONE to the display name (# 194)
* LoopKit: fix: Prevent app crash while moving presets (# 540)
* OmniBLE: PR 125, 126,127,128
* OmniKit: PR 36, 37, 38, 39

and the OmniXXX fixes are:
* update podState (Pump manager updates state following bolus, doesn't rely on top level code to do this - doesn't affect Loop, important for Trio)
* update logic to prevent bogus suspend error when bolusing after comms error
* Fix for perpetual Insert Cannula "Pod Already Paired" errors + Add optional mock error Preview handling code for testing
* hide back button on Deactivate screen to prevent dismiss with sideways pull

