### PR TITLE
✏️ Fix Broken Link to Trio Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This script is documented in
 
 This script is documented in
 
-* [*TrioDocs*: Build *Trio* with Script](https://docs.diy-trio.org/en/latest/operate/build.html#build-trio-with-script)
+* [*TrioDocs*: Build *Trio* with Script](https://docs.diy-trio.org/operate/build/#build-trio-with-script)
 
 ### Command to Execute Build Select Script
 


### PR DESCRIPTION
The change is due to the Trio Docs site [migration to Mkdocs](https://github.com/nightscout/trio-docs/pull/83) from Sphinx:
- the prefix `en/latest/` has been removed
- the `.html` suffix has been removed and replaced with a `/`