### PR TITLE
Potential improvement for issue when Loop misses G7 glucose readings

### DIFF
--- a/CustomizationSelect.sh
+++ b/CustomizationSelect.sh
@@ -755,6 +755,10 @@ function message_for_bolus_display() {
     printf "          https://github.com/LoopKit/Loop/pull/2264\n\n"
 }
 
+function message_for_g7_scan() {
+    printf "        This is a potential improvement for issue when Loop misses G7 glucose readings\n\n"
+}
+
 # list patches in this order with args:
 #   User facing information for option
 #   Folder name in the patch repo
@@ -782,6 +786,7 @@ add_customization "Live Activity/Dynamic Island" "live_activity" "message_for_li
 add_customization "Negative Insulin Damper" "negative_insulin" "message_for_negative_insulin"
 
 add_customization "Bolus Progress Display Fix" "bolus_display" "message_for_bolus_display"
+add_customization "G7 Missed Readings" "g7_scan" "message_for_g7_scan"
 
 add_translation "2002" "profiles"
 

--- a/src/CustomizationSelect.sh
+++ b/src/CustomizationSelect.sh
@@ -64,6 +64,10 @@ function message_for_bolus_display() {
     printf "          https://github.com/LoopKit/Loop/pull/2264\n\n"
 }
 
+function message_for_g7_scan() {
+    printf "        This is a potential improvement for issue when Loop misses G7 glucose readings\n\n"
+}
+
 # list patches in this order with args:
 #   User facing information for option
 #   Folder name in the patch repo
@@ -91,6 +95,7 @@ add_customization "Live Activity/Dynamic Island" "live_activity" "message_for_li
 add_customization "Negative Insulin Damper" "negative_insulin" "message_for_negative_insulin"
 
 add_customization "Bolus Progress Display Fix" "bolus_display" "message_for_bolus_display"
+add_customization "G7 Missed Readings" "g7_scan" "message_for_g7_scan"
 
 add_translation "2002" "profiles"
 


### PR DESCRIPTION
There have been a lot of reports of open source apps (Loop and Trio) not bringing in G7Sensor data even when the G7 app is working.

This proposed fix seems to improve the situation. Thanks to @motinis for proposing it and to the people who have tested it.

It cannot do anything for the case where the sensor itself is not sending data but appears to improve connectivity for Loop when the G7 Dexcom app is getting data.

This is an intermittent problem that only seems to affect some phone/sensor combinations.

See the discussion on zulipchat. Note that despite the name of the topic, this is observed in Loop 3.4.4 as well.
* https://loop.zulipchat.com/#narrow/channel/144182-development/topic/3.2E5.2E0.20Bluetooth.20oddities