### PR TITLE
update lightly tested SHA for loop-dev

### DIFF
--- a/BuildLoopDev.sh
+++ b/BuildLoopDev.sh
@@ -794,8 +794,8 @@ open_source_warning
 ############################################################
 
 # Stable Dev SHA
-FIXED_SHA="a32a19d"
-FIXED_COMMIT_DATE="2024-Aug-21"
+FIXED_SHA="194628d"
+FIXED_COMMIT_DATE="2025-Apr-24"
 FLAG_USE_SHA=0
 
 URL_THIS_SCRIPT="https://github.com/LoopKit/LoopWorkspace.git"

--- a/src/BuildLoopDev.sh
+++ b/src/BuildLoopDev.sh
@@ -24,8 +24,8 @@ open_source_warning
 ############################################################
 
 # Stable Dev SHA
-FIXED_SHA="a32a19d"
-FIXED_COMMIT_DATE="2024-Aug-21"
+FIXED_SHA="194628d"
+FIXED_COMMIT_DATE="2025-Apr-24"
 FLAG_USE_SHA=0
 
 URL_THIS_SCRIPT="https://github.com/LoopKit/LoopWorkspace.git"


### PR DESCRIPTION
Update the lightly tested SHA to match the most recent commit in dev, which at the current time is the same code (except for version number) as the Loop 3.6.0 release.