### PR TITLE
modify Build_iAPS to pull in submodules

### DIFF
--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -204,7 +204,7 @@ function erase_previous_line {
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 

--- a/BuildLoopCaregiver.sh
+++ b/BuildLoopCaregiver.sh
@@ -201,7 +201,7 @@ function erase_previous_line {
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 

--- a/BuildLoopFollow.sh
+++ b/BuildLoopFollow.sh
@@ -202,7 +202,7 @@ function erase_previous_line {
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 

--- a/BuildTrio.sh
+++ b/BuildTrio.sh
@@ -212,7 +212,7 @@ function erase_previous_line {
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 

--- a/Build_iAPS.sh
+++ b/Build_iAPS.sh
@@ -17,7 +17,7 @@ OVERRIDE_FILE="ConfigOverride.xcconfig"
 DEV_TEAM_SETTING_NAME="DEVELOPER_TEAM"
 
 # sub modules are not required
-CLONE_SUB_MODULES="0"
+CLONE_SUB_MODULES="1"
 
 FLAG_USE_SHA=0  # Initialize FLAG_USE_SHA to 0
 FIXED_SHA=""    # Initialize FIXED_SHA with an empty string
@@ -209,7 +209,7 @@ function erase_previous_line {
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 
@@ -986,6 +986,11 @@ before_final_return_message
 echo -e ""
 return_when_ready
 xed . 
+
+# iAPS does not seem to select FreeAPSWorkspace acutomatically
+echo -e "\n ${INFO_FONT}Make sure the FreeAPSWorkspace is selected before building${NC}"
+echo -e "    ${INFO_FONT}Do not build the CGMBLEKit Example scheme ${NC}"
+
 after_final_return_message
 exit_script
 # *** End of inlined file: src/Build_iAPS.sh ***

--- a/BuildxDrip4iOS.sh
+++ b/BuildxDrip4iOS.sh
@@ -209,7 +209,7 @@ function erase_previous_line {
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ Once you use an export command, that environment variable stays set in that Term
 * You can use the unset command to stay in the same Terminal
 * You can use CMD-N while in any Terminal window to open a new Terminal window, then switch to the new window
 
+### Old Repository
+
+Initially, these scripts were developed under a personal GitHub account: `loopnlearn`.
+
+Later, we configured the GitHub organization account `loopandlearn`.
+
+All new development happens in the [loopandlearn](https://github.com/loopandlearn) organization.
+
+As a courtesy to folks who find old links that refer to loopnlearn loopbuildscripts, that repository is kept up to date with the [loopandlearn lnl-scripts](https://github.com/loopandlearn/lnl-scripts) repository.
+
 ## Other Apps?
 
 Several apps are no longer found in lnl-scripts.

--- a/inline_functions/build_functions.sh
+++ b/inline_functions/build_functions.sh
@@ -27,7 +27,7 @@
 : ${USE_OVERRIDE_IN_REPO:="0"}
 
 # Default: some projects use submodules (and need --recurse-submodule)
-# Some, like iAPS and LoopFollow, do not use submodules
+# Some, like LoopFollow, do not use submodules
 #    in that case, set CLONE_SUB_MODULES to 0 in the src/Build script
 : ${CLONE_SUB_MODULES:="1"}
 

--- a/src/Build_iAPS.sh
+++ b/src/Build_iAPS.sh
@@ -12,7 +12,7 @@ OVERRIDE_FILE="ConfigOverride.xcconfig"
 DEV_TEAM_SETTING_NAME="DEVELOPER_TEAM"
 
 # sub modules are not required
-CLONE_SUB_MODULES="0"
+CLONE_SUB_MODULES="1"
 
 FLAG_USE_SHA=0  # Initialize FLAG_USE_SHA to 0
 FIXED_SHA=""    # Initialize FIXED_SHA with an empty string
@@ -143,5 +143,10 @@ before_final_return_message
 echo -e ""
 return_when_ready
 xed . 
+
+# iAPS does not seem to select FreeAPSWorkspace acutomatically
+echo -e "\n ${INFO_FONT}Make sure the FreeAPSWorkspace is selected before building${NC}"
+echo -e "    ${INFO_FONT}Do not build the CGMBLEKit Example scheme ${NC}"
+
 after_final_return_message
 exit_script


### PR DESCRIPTION
## Purpose

Enable continued use for people running iAPS.

## Method

The loopandlearn team noticed this PR: https://github.com/loopnlearn/loopbuildscripts/pull/59

* that PR modifies the Build_iAPS.sh script to handle the fact that iAPS now uses submodules instead of copies of shared repositories
* that PR was made against an old repository

New changes are always made to the loopandlearn / lnl-scripts repository and then pushed to the old repository.

This replacement PR is almost identical with the following exception:

* When testing this, the initial Xcode Scheme was CGMBLEKit Example instead of FreeAPSWorkspace
* An extra warning statement was added reminding users to select FreeAPSWorkspace before building