### PR TITLE
Update LATEST for iOS and Xcode

### DIFF
--- a/BuildLoop.sh
+++ b/BuildLoop.sh
@@ -365,14 +365,14 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
 #This is the highest version we expect users to have on their iPhones
-LATEST_IOS_VER="26.2"
+LATEST_IOS_VER="26.4.x"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
 LOWEST_XCODE_VER="16.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="26.2"
+LATEST_XCODE_VER="26.4"
 
 #This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="15.3"

--- a/BuildLoopCaregiver.sh
+++ b/BuildLoopCaregiver.sh
@@ -362,14 +362,14 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
 #This is the highest version we expect users to have on their iPhones
-LATEST_IOS_VER="26.2"
+LATEST_IOS_VER="26.4.x"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
 LOWEST_XCODE_VER="16.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="26.2"
+LATEST_XCODE_VER="26.4"
 
 #This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="15.3"

--- a/BuildLoopFollow.sh
+++ b/BuildLoopFollow.sh
@@ -363,14 +363,14 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
 #This is the highest version we expect users to have on their iPhones
-LATEST_IOS_VER="26.2"
+LATEST_IOS_VER="26.4.x"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
 LOWEST_XCODE_VER="16.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="26.2"
+LATEST_XCODE_VER="26.4"
 
 #This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="15.3"

--- a/BuildTrio.sh
+++ b/BuildTrio.sh
@@ -373,14 +373,14 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
 #This is the highest version we expect users to have on their iPhones
-LATEST_IOS_VER="26.2"
+LATEST_IOS_VER="26.4.x"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
 LOWEST_XCODE_VER="16.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="26.2"
+LATEST_XCODE_VER="26.4"
 
 #This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="15.3"

--- a/BuildxDrip4iOS.sh
+++ b/BuildxDrip4iOS.sh
@@ -370,14 +370,14 @@ CUSTOM_BRANCH=${1:-$CUSTOM_BRANCH}
 # *** Start of inlined file: inline_functions/building_verify_version.sh ***
 #This should be the latest iOS version
 #This is the highest version we expect users to have on their iPhones
-LATEST_IOS_VER="26.2"
+LATEST_IOS_VER="26.4.x"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
 LOWEST_XCODE_VER="16.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="26.2"
+LATEST_XCODE_VER="26.4"
 
 #This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="15.3"

--- a/inline_functions/building_verify_version.sh
+++ b/inline_functions/building_verify_version.sh
@@ -1,13 +1,13 @@
 #This should be the latest iOS version
 #This is the highest version we expect users to have on their iPhones
-LATEST_IOS_VER="26.2"
+LATEST_IOS_VER="26.4.x"
 
 #This should be the lowest xcode version required to build to LATEST_IOS_VER
 LOWEST_XCODE_VER="16.4"
 
 #This should be the latest known xcode version
 #LOWEST_XCODE_VER and LATEST_XCODE_VER will probably be equal but we should have suport for a span of these
-LATEST_XCODE_VER="26.2"
+LATEST_XCODE_VER="26.4"
 
 #This is the lowest version of macOS required to run LOWEST_XCODE_VER
 LOWEST_MACOS_VER="15.3"


### PR DESCRIPTION
Modify the constants for the latest versions for iOS and Xcode to 26.4.x and 26.4, respectively.