### PR TITLE
Add xdrip_cgm customization and submodule-fetch support

### DIFF
--- a/CustomizationSelect.sh
+++ b/CustomizationSelect.sh
@@ -233,6 +233,7 @@ status=()
 patch=()
 clean_build=()
 final_message=()
+submodule=()
 
 function add_customization() {
     customization+=("$1")
@@ -240,6 +241,10 @@ function add_customization() {
     message_function+=("$3")
     clean_build+=("$4")
     final_message+=("$5")
+    # Optional submodule path that this customization adds to .gitmodules and
+    # therefore must be fetched (cloned) after the patch is applied so that the
+    # referenced Xcode project exists. Leave blank for source-only patches.
+    submodule+=("$6")
 }
 
 folder_translation_from=()
@@ -394,6 +399,38 @@ function display_unapplicable_patches() {
     fi
 }
 
+# Clones the submodule a customization references (reading the URL the patch
+# just added to .gitmodules) so the referenced Xcode project exists. The patch
+# itself only edits .gitmodules/workspace/scheme; the source must be fetched.
+function fetch_customization_submodule {
+    local sub_path="$1"
+    [ -z "$sub_path" ] && return 0
+    if [ -e "$sub_path/.git" ]; then
+        return 0  # already present, nothing to do
+    fi
+    local sub_url
+    sub_url=$(git config -f .gitmodules --get "submodule.${sub_path}.url" 2>/dev/null)
+    if [ -z "$sub_url" ]; then
+        echo -e "${ERROR_FONT}  Could not find URL for submodule $sub_path in .gitmodules${NC}"
+        return 1
+    fi
+    echo -e "${INFO_FONT}  Fetching $sub_path, please wait  ...  patiently  ...${NC}"
+    if git clone --quiet "$sub_url" "$sub_path"; then
+        erase_previous_line
+        return 0
+    fi
+    echo -e "${ERROR_FONT}  Failed to clone $sub_path from $sub_url${NC}"
+    return 1
+}
+
+# Removes a submodule directory that a customization added, so that reverting
+# the customization fully restores the workspace.
+function remove_customization_submodule {
+    local sub_path="$1"
+    [ -z "$sub_path" ] && return 0
+    [ -d "$sub_path" ] && rm -rf "$sub_path"
+}
+
 function apply_patch {
     local index=$1
     local patch_file="${patch[$index]}"
@@ -409,6 +446,9 @@ function apply_patch {
     
         if git apply --whitespace=nowarn "$patch_file"; then
             echo -e "${SUCCESS_FONT}  Customization $customization_name applied successfully${NC}"
+            if [ -n "${submodule[$index]}" ]; then
+                fetch_customization_submodule "${submodule[$index]}" || return_when_ready
+            fi
             if [ "${clean_build[$index]}" == "1" ]; then
                 echo -e "${INFO_FONT}  Cleaning build folder, please wait  ...  patiently  ...${NC}"
                 xcodebuild -quiet -workspace "${workingdir}/LoopWorkspace.xcworkspace" -scheme LoopWorkspace clean 2>/dev/null
@@ -432,6 +472,9 @@ function apply_patch_command_line {
     if [ -f "$patch_file" ]; then
         if git apply --whitespace=nowarn "$patch_file"; then
             echo -e "${SUCCESS_FONT}  Customization $customization_name applied successfully${NC}"
+            if [ -n "${submodule[$index]}" ]; then
+                fetch_customization_submodule "${submodule[$index]}" || exit 1
+            fi
         else
             echo -e "${ERROR_FONT}  Failed to apply customization $customization_name${NC}"
             exit 1
@@ -458,6 +501,9 @@ function revert_patch {
         
         if git apply --whitespace=nowarn --reverse "$patch_file"; then
             echo -e "${SUCCESS_FONT}  Customization $customization_name reverted successfully${NC}"
+            if [ -n "${submodule[$index]}" ]; then
+                remove_customization_submodule "${submodule[$index]}"
+            fi
             if [ "${clean_build[$index]}" == "1" ]; then
                 echo -e "${INFO_FONT}  Cleaning build folder, please wait  ...  patiently  ...${NC}"
                 xcodebuild -quiet -workspace "${workingdir}/LoopWorkspace.xcworkspace" -scheme LoopWorkspace clean 2>/dev/null
@@ -755,10 +801,19 @@ function message_for_remote_window() {
     printf "            https://www.loopandlearn.org/loop-features-in-development#remote-window\n\n"
 }
 
+function message_for_xdrip() {
+    printf "        Add xDrip4iOS as a CGM source for Loop using a shared App Group\n"
+    printf "        Applying this also clones the xdrip-client-swift plugin into the workspace\n"
+    printf "          https://www.loopandlearn.org/custom-code#custom-list\n\n"
+}
+
 # list patches in this order with args:
 #   User facing information for option
 #   Folder name in the patch repo
 #   (Optional) message function shown prior to option
+#   (Optional) clean_build flag ("1" to clean the build folder)
+#   (Optional) final_message shown (with a pause) before applying
+#   (Optional) submodule path to clone after the patch is applied
 
 add_customization "(Included in 3.10.0) Change Default to Upload Dexcom Readings" "dexcom_upload_readings"
 add_customization "Increase Future Carbs Limit to 4 hours" "future_carbs_4h"
@@ -782,6 +837,10 @@ add_customization "(Included in 3.10.0) Live Activity/Dynamic Island" "live_acti
 add_customization "Negative Insulin Damper" "negative_insulin" "message_for_negative_insulin"
 
 add_customization "Increase Remote Window to 10 minutes" "remote_window" "message_for_remote_window"
+
+# xdrip_cgm adds the xdrip-client-swift submodule, so the 6th arg tells the
+# script to clone it after the patch is applied
+add_customization "Add xDrip4iOS as a CGM (clones xdrip-client-swift)" "xdrip_cgm" "message_for_xdrip" "" "" "xdrip-client-swift"
 
 add_translation "2002" "profiles"
 

--- a/inline_functions/patch_functions.sh
+++ b/inline_functions/patch_functions.sh
@@ -62,6 +62,7 @@ status=()
 patch=()
 clean_build=()
 final_message=()
+submodule=()
 
 function add_customization() {
     customization+=("$1")
@@ -69,6 +70,10 @@ function add_customization() {
     message_function+=("$3")
     clean_build+=("$4")
     final_message+=("$5")
+    # Optional submodule path that this customization adds to .gitmodules and
+    # therefore must be fetched (cloned) after the patch is applied so that the
+    # referenced Xcode project exists. Leave blank for source-only patches.
+    submodule+=("$6")
 }
 
 folder_translation_from=()
@@ -223,6 +228,38 @@ function display_unapplicable_patches() {
     fi
 }
 
+# Clones the submodule a customization references (reading the URL the patch
+# just added to .gitmodules) so the referenced Xcode project exists. The patch
+# itself only edits .gitmodules/workspace/scheme; the source must be fetched.
+function fetch_customization_submodule {
+    local sub_path="$1"
+    [ -z "$sub_path" ] && return 0
+    if [ -e "$sub_path/.git" ]; then
+        return 0  # already present, nothing to do
+    fi
+    local sub_url
+    sub_url=$(git config -f .gitmodules --get "submodule.${sub_path}.url" 2>/dev/null)
+    if [ -z "$sub_url" ]; then
+        echo -e "${ERROR_FONT}  Could not find URL for submodule $sub_path in .gitmodules${NC}"
+        return 1
+    fi
+    echo -e "${INFO_FONT}  Fetching $sub_path, please wait  ...  patiently  ...${NC}"
+    if git clone --quiet "$sub_url" "$sub_path"; then
+        erase_previous_line
+        return 0
+    fi
+    echo -e "${ERROR_FONT}  Failed to clone $sub_path from $sub_url${NC}"
+    return 1
+}
+
+# Removes a submodule directory that a customization added, so that reverting
+# the customization fully restores the workspace.
+function remove_customization_submodule {
+    local sub_path="$1"
+    [ -z "$sub_path" ] && return 0
+    [ -d "$sub_path" ] && rm -rf "$sub_path"
+}
+
 function apply_patch {
     local index=$1
     local patch_file="${patch[$index]}"
@@ -238,6 +275,9 @@ function apply_patch {
     
         if git apply --whitespace=nowarn "$patch_file"; then
             echo -e "${SUCCESS_FONT}  Customization $customization_name applied successfully${NC}"
+            if [ -n "${submodule[$index]}" ]; then
+                fetch_customization_submodule "${submodule[$index]}" || return_when_ready
+            fi
             if [ "${clean_build[$index]}" == "1" ]; then
                 echo -e "${INFO_FONT}  Cleaning build folder, please wait  ...  patiently  ...${NC}"
                 xcodebuild -quiet -workspace "${workingdir}/LoopWorkspace.xcworkspace" -scheme LoopWorkspace clean 2>/dev/null
@@ -261,6 +301,9 @@ function apply_patch_command_line {
     if [ -f "$patch_file" ]; then
         if git apply --whitespace=nowarn "$patch_file"; then
             echo -e "${SUCCESS_FONT}  Customization $customization_name applied successfully${NC}"
+            if [ -n "${submodule[$index]}" ]; then
+                fetch_customization_submodule "${submodule[$index]}" || exit 1
+            fi
         else
             echo -e "${ERROR_FONT}  Failed to apply customization $customization_name${NC}"
             exit 1
@@ -287,6 +330,9 @@ function revert_patch {
         
         if git apply --whitespace=nowarn --reverse "$patch_file"; then
             echo -e "${SUCCESS_FONT}  Customization $customization_name reverted successfully${NC}"
+            if [ -n "${submodule[$index]}" ]; then
+                remove_customization_submodule "${submodule[$index]}"
+            fi
             if [ "${clean_build[$index]}" == "1" ]; then
                 echo -e "${INFO_FONT}  Cleaning build folder, please wait  ...  patiently  ...${NC}"
                 xcodebuild -quiet -workspace "${workingdir}/LoopWorkspace.xcworkspace" -scheme LoopWorkspace clean 2>/dev/null

--- a/src/CustomizationSelect.sh
+++ b/src/CustomizationSelect.sh
@@ -64,10 +64,19 @@ function message_for_remote_window() {
     printf "            https://www.loopandlearn.org/loop-features-in-development#remote-window\n\n"
 }
 
+function message_for_xdrip() {
+    printf "        Add xDrip4iOS as a CGM source for Loop using a shared App Group\n"
+    printf "        Applying this also clones the xdrip-client-swift plugin into the workspace\n"
+    printf "          https://www.loopandlearn.org/custom-code#custom-list\n\n"
+}
+
 # list patches in this order with args:
 #   User facing information for option
 #   Folder name in the patch repo
 #   (Optional) message function shown prior to option
+#   (Optional) clean_build flag ("1" to clean the build folder)
+#   (Optional) final_message shown (with a pause) before applying
+#   (Optional) submodule path to clone after the patch is applied
 
 add_customization "(Included in 3.10.0) Change Default to Upload Dexcom Readings" "dexcom_upload_readings"
 add_customization "Increase Future Carbs Limit to 4 hours" "future_carbs_4h"
@@ -91,6 +100,10 @@ add_customization "(Included in 3.10.0) Live Activity/Dynamic Island" "live_acti
 add_customization "Negative Insulin Damper" "negative_insulin" "message_for_negative_insulin"
 
 add_customization "Increase Remote Window to 10 minutes" "remote_window" "message_for_remote_window"
+
+# xdrip_cgm adds the xdrip-client-swift submodule, so the 6th arg tells the
+# script to clone it after the patch is applied
+add_customization "Add xDrip4iOS as a CGM (clones xdrip-client-swift)" "xdrip_cgm" "message_for_xdrip" "" "" "xdrip-client-swift"
 
 add_translation "2002" "profiles"
 


### PR DESCRIPTION
## Purpose

Add the **Add xDrip4iOS as a CGM** customization to CustomizationSelect, and add support for customizations that introduce a new submodule.

Pairs with the patch in loopandlearn/customization#65 (branch `xdrip_cgm`).

## Method

* New menu entry `add_customization "Add xDrip4iOS as a CGM (clones xdrip-client-swift)" "xdrip_cgm" ...`
* `add_customization` gains an optional sixth argument: the path of a submodule the customization adds. When present, after the patch applies the script clones that repository using the URL the patch added to `.gitmodules` (so the referenced Xcode project exists), and removes the directory when the customization is reverted. This mirrors how the GitHub-action build clones `xdrip-client-swift`.
* Existing source-only customizations are unaffected (empty sixth argument).
* Regenerated `CustomizationSelect.sh` from `src/`.

## Dependency

The patch itself lives in loopandlearn/customization#65. The test commands below fetch this branch's `CustomizationSelect.sh` and point `PATCH_BRANCH` at the matching customization branch.

## Test

### reset command

```
git submodule foreach 'git reset --hard; git clean -fd;'
```

### apply

```
export PATCH_BRANCH="xdrip_cgm"
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/loopandlearn/lnl-scripts/xdrip_cgm/CustomizationSelect.sh)" \
    xdrip_cgm
unset PATCH_BRANCH
```

Confirm the patch applies, `xdrip-client-swift/` is cloned, `xdrip-client-swift/xDripClient.xcodeproj` exists, and that reverting the customization both reverses the patch and removes the cloned directory.
