### PR TITLE
Honor an optional submodule ref when fetching a customization submodule

### DIFF
--- a/CustomizationSelect.sh
+++ b/CustomizationSelect.sh
@@ -416,6 +416,15 @@ function fetch_customization_submodule {
     fi
     echo -e "${INFO_FONT}  Fetching $sub_path, please wait  ...  patiently  ...${NC}"
     if git clone --quiet "$sub_url" "$sub_path"; then
+        # Optional ref pin: if .gitmodules specifies a branch/tag/SHA for this
+        # submodule, check it out so a customization can lock a specific version
+        # (e.g. keep dev/main on one commit while next-dev uses another).
+        local sub_ref
+        sub_ref=$(git config -f .gitmodules --get "submodule.${sub_path}.branch" 2>/dev/null)
+        if [ -n "$sub_ref" ] && ! git -C "$sub_path" checkout --quiet "$sub_ref"; then
+            echo -e "${ERROR_FONT}  Could not check out ref '$sub_ref' for $sub_path${NC}"
+            return 1
+        fi
         erase_previous_line
         return 0
     fi

--- a/inline_functions/patch_functions.sh
+++ b/inline_functions/patch_functions.sh
@@ -245,6 +245,15 @@ function fetch_customization_submodule {
     fi
     echo -e "${INFO_FONT}  Fetching $sub_path, please wait  ...  patiently  ...${NC}"
     if git clone --quiet "$sub_url" "$sub_path"; then
+        # Optional ref pin: if .gitmodules specifies a branch/tag/SHA for this
+        # submodule, check it out so a customization can lock a specific version
+        # (e.g. keep dev/main on one commit while next-dev uses another).
+        local sub_ref
+        sub_ref=$(git config -f .gitmodules --get "submodule.${sub_path}.branch" 2>/dev/null)
+        if [ -n "$sub_ref" ] && ! git -C "$sub_path" checkout --quiet "$sub_ref"; then
+            echo -e "${ERROR_FONT}  Could not check out ref '$sub_ref' for $sub_path${NC}"
+            return 1
+        fi
         erase_previous_line
         return 0
     fi


### PR DESCRIPTION
`fetch_customization_submodule` currently does a plain `git clone` of the submodule's default branch. This adds: if the `.gitmodules` entry a customization added includes a `branch` value, check it out after cloning — works for a branch, tag, or SHA.

This lets a customization **pin a specific plugin version**. Concretely, it enables keeping the current `xdrip_cgm` on the plugin's current SHA for dev/main, while a next-dev variant points at a different (ported) ref of a fork.

Backward-compatible: no-op when no `branch` is set, so existing customizations are unchanged.
